### PR TITLE
tf: fix benchmarking standalone apm to use x86_64 AMI by default

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -153,7 +153,7 @@ module "standalone_apm_server" {
   source = "../infra/terraform/modules/standalone_apm_server"
 
   vpc_id              = module.vpc.vpc_id
-  aws_os              = "al2023-ami-2023"
+  aws_os              = "al2023-ami-2023.*-x86_64"
   apm_instance_type   = var.standalone_apm_server_instance_size
   apm_volume_type     = var.standalone_apm_server_volume_type
   apm_volume_size     = var.apm_server_tail_sampling ? coalesce(var.standalone_apm_server_volume_size, 60) : var.standalone_apm_server_volume_size

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -5,6 +5,7 @@ locals {
     "ubuntu-noble-24.04-arm64-server" = "099720109477" # canonical
     "debian-12-arm64"                 = "136693071363" # debian
     "al2023-ami-2023"                 = "137112412989" # amazon
+    "al2023-ami-2023.*-x86_64"        = "137112412989" # amazon
     "RHEL-8"                          = "309956199498" # Red Hat
     "RHEL-9"                          = "309956199498" # Red Hat
   }
@@ -14,6 +15,7 @@ locals {
     "ubuntu-noble-24.04-arm64-server" = "t4g.nano"
     "debian-12-arm64"                 = "t4g.nano"
     "al2023-ami-2023"                 = "t4g.nano"
+    "al2023-ami-2023.*-x86_64"        = "t3a.micro"
     "RHEL-8"                          = "t4g.micro" # RHEL doesn't support nano instances
     "RHEL-9"                          = "t4g.micro" # RHEL doesn't support nano instances
   }
@@ -23,6 +25,7 @@ locals {
     "ubuntu-noble-24.04-arm64-server" = "arm64"
     "debian-12-arm64"                 = "arm64"
     "al2023-ami-2023"                 = "arm64"
+    "al2023-ami-2023.*-x86_64"        = "x86_64"
     "RHEL-8"                          = "arm64"
     "RHEL-9"                          = "arm64"
   }
@@ -32,6 +35,7 @@ locals {
     "ubuntu-noble-24.04-arm64-server" = "curl ${data.external.latest_elastic_agent.result.deb_arm} -o elastic-agent.deb && sudo dpkg -i elastic-agent.deb"
     "debian-12-arm64"                 = "curl ${data.external.latest_elastic_agent.result.deb_arm} -o elastic-agent.deb && sudo dpkg -i elastic-agent.deb"
     "al2023-ami-2023"                 = "curl ${data.external.latest_elastic_agent.result.rpm_arm} -o elastic-agent.rpm && sudo yum -y install elastic-agent.rpm"
+    "al2023-ami-2023.*-x86_64"        = "curl ${data.external.latest_elastic_agent.result.rpm_arm} -o elastic-agent.rpm && sudo yum -y install elastic-agent.rpm"
     "RHEL-8"                          = "curl ${data.external.latest_elastic_agent.result.rpm_arm} -o elastic-agent.rpm && sudo yum -y install elastic-agent.rpm"
     "RHEL-9"                          = "curl ${data.external.latest_elastic_agent.result.rpm_arm} -o elastic-agent.rpm && sudo yum -y install elastic-agent.rpm"
   }
@@ -41,6 +45,7 @@ locals {
     "ubuntu-noble-24.04-arm64-server" = "curl ${data.external.latest_apm_server.result.deb_arm} -o apm-server.deb && sudo dpkg -i apm-server.deb"
     "debian-12-arm64"                 = "curl ${data.external.latest_apm_server.result.deb_arm} -o apm-server.deb && sudo dpkg -i apm-server.deb"
     "al2023-ami-2023"                 = "curl ${data.external.latest_apm_server.result.rpm_arm} -o apm-server.rpm && sudo yum -y install apm-server.rpm"
+    "al2023-ami-2023.*-x86_64"        = "curl ${data.external.latest_apm_server.result.rpm_arm} -o apm-server.rpm && sudo yum -y install apm-server.rpm"
     "RHEL-8"                          = "curl ${data.external.latest_apm_server.result.rpm_arm} -o apm-server.rpm && sudo yum -y install apm-server.rpm"
     "RHEL-9"                          = "curl ${data.external.latest_apm_server.result.rpm_arm} -o apm-server.rpm && sudo yum -y install apm-server.rpm"
   }
@@ -50,6 +55,7 @@ locals {
     "ubuntu-noble-24.04-arm64-server" = "ubuntu"
     "debian-12-arm64"                 = "admin"
     "al2023-ami-2023"                 = "ec2-user"
+    "al2023-ami-2023.*-x86_64"        = "ec2-user"
     "RHEL-8"                          = "ec2-user"
     "RHEL-9"                          = "ec2-user"
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Fix a regression where benchmarking standalone apm server does not find a matching x86_64 AMI for c6i instance types.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #15604
