### PR TITLE
test: add back support from upgrading from 7

### DIFF
--- a/testing/smoke/basic-upgrade/test.sh
+++ b/testing/smoke/basic-upgrade/test.sh
@@ -16,7 +16,13 @@ fi
 MAJOR_VERSION=$(echo ${VERSION} | cut -d '.' -f1 )
 MINOR_VERSION=$(echo ${VERSION} | cut -d '.' -f2 )
 
-if [[ ${MAJOR_VERSION} -eq 8 ]] || [[ ${MAJOR_VERSION} -eq 9 ]]; then
+if [[ ${MAJOR_VERSION} -eq 7 ]]; then
+    ASSERT_EVENTS_FUNC=legacy_assertions
+    INTEGRATIONS_SERVER=false
+    get_latest_patch "${MAJOR_VERSION}.${MINOR_VERSION}"
+    LATEST_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}.${LATEST_PATCH}
+    PREV_LATEST_VERSION=$(echo ${MAJOR_VERSION}.${MINOR_VERSION}.$(( ${LATEST_PATCH} -1 )))
+elif [[ ${MAJOR_VERSION} -eq 8 ]] || [[ ${MAJOR_VERSION} -eq 9 ]]; then
     ASSERT_EVENTS_FUNC=data_stream_assertions
     INTEGRATIONS_SERVER=true
 


### PR DESCRIPTION
## Motivation/summary

this is still supported until 9 is out

they were removed in https://github.com/elastic/apm-server/pull/15608

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
