### PR TITLE
benchmark: increase worker instance size

### DIFF
--- a/testing/benchmark/system-profiles/8GBx1zone.tfvars
+++ b/testing/benchmark/system-profiles/8GBx1zone.tfvars
@@ -2,7 +2,7 @@ user_name = "USER"
 
 # APM bench
 
-worker_instance_type = "c6i.xlarge"
+worker_instance_type = "c6i.2xlarge"
 
 # Elastic Cloud
 


### PR DESCRIPTION
Doubles the worker instance size to see if it stabilizes the benchmark. The worker is currently running out of memory after 3h of running the benchmark.

