### PR TITLE
functionaltests: disable scheduled run

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -3,8 +3,9 @@ name: functional-tests
 
 on:
   workflow_dispatch: ~
-  schedule:
-    - cron: '0 3 * * 1-5'
+  # TODO: re-enable this once they run reliably
+  # schedule:
+  #   - cron: '0 3 * * 1-5'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Functional tests have not been reliable in the last weeks. Either QA or Prod tests are failing due to https://github.com/elastic/apm-server/issues/15531

A stable resolution is not ready yet, and we are being notified of failures that are not actionable. To prevent alert fatigue, disable the scheduled run while we work on a complete resolution.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
https://github.com/elastic/apm-server/issues/14100
