### PR TITLE
refactor: do not try to seed the rng

### DIFF
--- a/internal/beatcmd/init.go
+++ b/internal/beatcmd/init.go
@@ -18,12 +18,6 @@
 package beatcmd
 
 import (
-	cryptorand "crypto/rand"
-	"math"
-	"math/big"
-	"math/rand"
-	"time"
-
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	_ "github.com/elastic/beats/v7/libbeat/monitoring/report/elasticsearch" // register default monitoring reporting
 	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
@@ -36,19 +30,7 @@ import (
 )
 
 func init() {
-	initRand()
 	initFlags()
-}
-
-func initRand() {
-	n, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64))
-	var seed int64
-	if err != nil {
-		seed = time.Now().UnixNano()
-	} else {
-		seed = n.Int64()
-	}
-	rand.Seed(seed) //lint:ignore SA1019 libbeat uses deprecated math/rand functions prolifically
 }
 
 func initFlags() {


### PR DESCRIPTION
## Motivation/summary

beats moved to math/rand/v2 and go automatically seeds the rng with a random value.
In the future the seed func will be a no op.
Remove init to reseed the rng

This is not exactly fips-related but it came up while reviewing crypto usage (seed calls crypto rng to seed the non-crypto rng)

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
