### PR TITLE
CI(smoketest): fetch previous version on first minor

### DIFF
--- a/testing/smoke/basic-upgrade/test.sh
+++ b/testing/smoke/basic-upgrade/test.sh
@@ -29,9 +29,15 @@ elif [[ ${MAJOR_VERSION} -eq 8 ]] || [[ ${MAJOR_VERSION} -eq 9 ]]; then
     get_latest_patch "${MAJOR_VERSION}.${MINOR_VERSION}"
     LATEST_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}.${LATEST_PATCH}
 
-    PREV_MINOR=$(( ${MINOR_VERSION} -1 ))
-    get_latest_patch "${MAJOR_VERSION}.${PREV_MINOR}"
-    PREV_LATEST_VERSION=${MAJOR_VERSION}.${PREV_MINOR}.${LATEST_PATCH}
+    # when the minor is 0, we want to fetch the latest patch of the previous major
+    if [[ ${MINOR_VERSION} -eq 0 ]]; then
+        PREV_MAJOR=$(( ${MAJOR_VERSION} -1 ))
+        PREV_LATEST_VERSION=$(get_latest_version "${PREV_MAJOR}")
+    else
+      PREV_MINOR=$(( ${MINOR_VERSION} -1 ))
+      get_latest_patch "${MAJOR_VERSION}.${PREV_MINOR}"
+      PREV_LATEST_VERSION=${MAJOR_VERSION}.${PREV_MINOR}.${LATEST_PATCH}
+    fi
 else
     echo "version ${VERSION} not supported"
     exit 5

--- a/testing/smoke/lib.sh
+++ b/testing/smoke/lib.sh
@@ -21,8 +21,14 @@ get_versions() {
     VERSIONS=$(echo "${RES}" | jq -r -c '[.stacks[].version | select(. | contains("-") | not)] | sort_by(.| split(".") | map(tonumber))')
 }
 
+get_latest_version() {
+    local version
+    version=$(echo ${VERSIONS} | jq -r -c "max_by(. | select(. | startswith(\"${1}\")) | if endswith(\"-SNAPSHOT\") then .[:-9] else . end | split(\".\") | map(tonumber))")
+    echo "${version}"
+}
+
 get_latest_patch() {
-    LATEST_PATCH=$(echo ${VERSIONS} | jq -r -c "max_by(. | select(. | startswith(\"${1}\")) | if endswith(\"-SNAPSHOT\") then .[:-9] else . end | split(\".\") | map(tonumber))" | cut -d '.' -f3)
+    LATEST_PATCH=$(get_latest_version "${1}" | cut -d '.' -f3)
 }
 
 get_latest_snapshot() {


### PR DESCRIPTION
### Reason for this PR

Fixing smoke tests `basic-upgrade` that is failing fetching a negative minor version from the ECH API.

```
-> unspecified version, using 9.0
-> Running basic upgrade smoke test for version 9.0.0
-> Adding tfvar stack_version="9.-1.0"
```

### Details

Introduce a new function in smoke tests `lib.sh` to fetch the full latest version of a given prefix.
Use that function to populate the previous major latest minor.patch.
