### PR TITLE
feat: purge more noisy kerberos libs from docker image 

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -93,7 +93,7 @@ RUN chown -R 1000:1000 /usr/share/apm-server
 
 # remove unnecessary packages in ubuntu-based images
 # use rpm to ignore ubi images
-RUN rpm -v || (dpkg -r --force-depends libgssapi-krb5-2 libtirpc3 libnsl2 && \
+RUN rpm -v || (dpkg -r --force-depends libgssapi-krb5-2 libtirpc3 libnsl2 libkrb5 libkr5crypto libkrb5support0 && \
     rm /var/log/dpkg.log)
 
 USER apm-server


### PR DESCRIPTION
## Motivation/summary

Similar to https://github.com/elastic/apm-server/pull/15788 but different kerberos lib

we don't need/use it. Remove it to avoid noisy alerts

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
