### PR TITLE
fix(docker): move to purge and update krb lib name

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -93,7 +93,7 @@ RUN chown -R 1000:1000 /usr/share/apm-server
 
 # remove unnecessary packages in ubuntu-based images
 # use rpm to ignore ubi images
-RUN rpm -v || (dpkg -r --force-depends libgssapi-krb5-2 libtirpc3 libnsl2 libkrb5 libkr5crypto libkrb5support0 && \
+RUN rpm -v || (dpkg -P --force-depends libgssapi-krb5-2 libtirpc3 libnsl2 libkrb5-3 libkr5crypto libkrb5support0 && \
     rm /var/log/dpkg.log)
 
 USER apm-server


### PR DESCRIPTION
## Motivation/summary

libkrb5 is actually called libkrb5-3
use dpkg -P instead of -r to remove any leftover files

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

docker build -f packaging/docker/Dockerfile --build-arg GOLANG_VERSION=1.23 .

inspect the docker image to validate krb libs are removed

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
