### PR TITLE
test: Fix flaky esoutput

### DIFF
--- a/internal/beater/monitoringtest/opentelemetry.go
+++ b/internal/beater/monitoringtest/opentelemetry.go
@@ -83,7 +83,7 @@ func ExpectContainOtelMetricsKeys(t *testing.T, reader sdkmetric.Reader, expecte
 // assertOtelMetrics gathers all the metrics from `reader` and runs the AssertionFunc for all metrics specified
 // in `expectedMetrics`.
 //
-// If `fullMatch` is true, all metrics from `reader` must be found in `expectedMetrics`.
+// If `fullMatch` is true, all metrics from `reader` must be found in `expectedMetrics` vice versa.
 // Otherwise, only the metrics in `expectedMetrics` will be checked.
 //
 // If `skipValAssert` is true, the AssertionFunc(s) will be skipped entirely.

--- a/internal/beater/monitoringtest/opentelemetry.go
+++ b/internal/beater/monitoringtest/opentelemetry.go
@@ -26,23 +26,73 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-func ExpectOtelMetrics(t *testing.T, reader sdkmetric.Reader, expectedMetrics map[string]any) {
-	assertOtelMetrics(t, reader, expectedMetrics, true, true)
+type AssertionFunc func(t *testing.T, actual any) bool
+
+func ExpectOtelMetricsFunc(
+	t *testing.T,
+	reader sdkmetric.Reader,
+	expectedMetrics map[string]AssertionFunc,
+) {
+	assertOtelMetrics(t, reader, expectedMetrics, true, false)
 }
 
-func ExpectContainOtelMetrics(t *testing.T, reader sdkmetric.Reader, expectedMetrics map[string]any) {
-	assertOtelMetrics(t, reader, expectedMetrics, false, true)
+func ExpectOtelMetrics(
+	t *testing.T,
+	reader sdkmetric.Reader,
+	expectedMetricsValue map[string]any,
+) {
+	expectedMetrics := make(map[string]AssertionFunc)
+	for k, v := range expectedMetricsValue {
+		expectedMetrics[k] = func(t *testing.T, actual any) bool {
+			return assert.EqualValues(t, v, actual)
+		}
+	}
+	assertOtelMetrics(t, reader, expectedMetrics, true, false)
 }
 
-func ExpectContainOtelMetricsKeys(t *testing.T, reader sdkmetric.Reader, expectedMetricsKeys []string) {
-	expectedMetrics := make(map[string]any)
-	for _, metricKey := range expectedMetricsKeys {
-		expectedMetrics[metricKey] = nil
+func ExpectContainOtelMetricsFunc(
+	t *testing.T,
+	reader sdkmetric.Reader,
+	expectedMetrics map[string]AssertionFunc,
+) {
+	assertOtelMetrics(t, reader, expectedMetrics, false, false)
+}
+
+func ExpectContainOtelMetrics(
+	t *testing.T,
+	reader sdkmetric.Reader,
+	expectedMetricsValue map[string]any,
+) {
+	expectedMetrics := make(map[string]AssertionFunc)
+	for k, v := range expectedMetricsValue {
+		expectedMetrics[k] = func(t *testing.T, actual any) bool {
+			return assert.EqualValues(t, v, actual)
+		}
 	}
 	assertOtelMetrics(t, reader, expectedMetrics, false, false)
 }
 
-func assertOtelMetrics(t *testing.T, reader sdkmetric.Reader, expectedMetrics map[string]any, match, matchVal bool) {
+func ExpectContainOtelMetricsKeys(t *testing.T, reader sdkmetric.Reader, expectedMetricsKeys []string) {
+	expectedMetrics := make(map[string]AssertionFunc)
+	for _, metricKey := range expectedMetricsKeys {
+		expectedMetrics[metricKey] = nil
+	}
+	assertOtelMetrics(t, reader, expectedMetrics, false, true)
+}
+
+// assertOtelMetrics gathers all the metrics from `reader` and runs the AssertionFunc for all metrics specified
+// in `expectedMetrics`.
+//
+// If `fullMatch` is true, all metrics from `reader` must be found in `expectedMetrics`.
+// Otherwise, only the metrics in `expectedMetrics` will be checked.
+//
+// If `skipValAssert` is true, the AssertionFunc(s) will be skipped entirely.
+func assertOtelMetrics(
+	t *testing.T,
+	reader sdkmetric.Reader,
+	expectedMetrics map[string]AssertionFunc,
+	fullMatch, skipValAssert bool,
+) {
 	t.Helper()
 
 	var rm metricdata.ResourceMetrics
@@ -56,49 +106,39 @@ func assertOtelMetrics(t *testing.T, reader sdkmetric.Reader, expectedMetrics ma
 			case metricdata.Gauge[int64]:
 				assert.Equal(t, 1, len(d.DataPoints))
 				foundMetrics = append(foundMetrics, m.Name)
-				if !matchVal {
+				if skipValAssert {
 					continue
 				}
 
-				if v, ok := expectedMetrics[m.Name]; ok {
-					if dp, ok := v.(int); ok {
-						assert.Equal(t, int64(dp), d.DataPoints[0].Value, m.Name)
-					} else {
-						assert.Fail(t, "expected an int value", m.Name)
-					}
-				} else if match {
+				if fn, ok := expectedMetrics[m.Name]; ok {
+					assert.True(t, fn(t, d.DataPoints[0].Value), m.Name)
+				} else if fullMatch {
 					assert.Fail(t, "unexpected metric", m.Name)
 				}
+
 			case metricdata.Sum[int64]:
 				assert.Equal(t, 1, len(d.DataPoints))
 				foundMetrics = append(foundMetrics, m.Name)
-				if !matchVal {
+				if skipValAssert {
 					continue
 				}
 
-				if v, ok := expectedMetrics[m.Name]; ok {
-					if dp, ok := v.(int); ok {
-						assert.Equal(t, int64(dp), d.DataPoints[0].Value, m.Name)
-					} else {
-						assert.Fail(t, "expected an int value", m.Name)
-					}
-				} else if match {
+				if fn, ok := expectedMetrics[m.Name]; ok {
+					assert.True(t, fn(t, d.DataPoints[0].Value), m.Name)
+				} else if fullMatch {
 					assert.Fail(t, "unexpected metric", m.Name)
 				}
+
 			case metricdata.Histogram[int64]:
 				assert.Equal(t, 1, len(d.DataPoints))
 				foundMetrics = append(foundMetrics, m.Name)
-				if !matchVal {
+				if skipValAssert {
 					continue
 				}
 
-				if v, ok := expectedMetrics[m.Name]; ok {
-					if dp, ok := v.(int); ok {
-						assert.Equal(t, uint64(dp), d.DataPoints[0].Count, m.Name)
-					} else {
-						assert.Fail(t, "expected an int value", m.Name)
-					}
-				} else if match {
+				if fn, ok := expectedMetrics[m.Name]; ok {
+					assert.True(t, fn(t, d.DataPoints[0].Count), m.Name)
+				} else if fullMatch {
 					assert.Fail(t, "unexpected metric", m.Name)
 				}
 			}
@@ -109,7 +149,7 @@ func assertOtelMetrics(t *testing.T, reader sdkmetric.Reader, expectedMetrics ma
 	for k := range expectedMetrics {
 		expectedMetricsKeys = append(expectedMetricsKeys, k)
 	}
-	if match {
+	if fullMatch {
 		assert.ElementsMatch(t, expectedMetricsKeys, foundMetrics)
 	} else {
 		assert.Subset(t, foundMetrics, expectedMetricsKeys)

--- a/internal/beater/monitoringtest/opentelemetry.go
+++ b/internal/beater/monitoringtest/opentelemetry.go
@@ -80,11 +80,11 @@ func ExpectContainOtelMetricsKeys(t *testing.T, reader sdkmetric.Reader, expecte
 	assertOtelMetrics(t, reader, expectedMetrics, false, true)
 }
 
-// assertOtelMetrics gathers all the metrics from `reader` and runs the AssertionFunc for all metrics specified
-// in `expectedMetrics`.
+// assertOtelMetrics gathers all the metrics from `reader` and runs the AssertionFunc for those gathered metrics
+// whose keys are specified in `expectedMetrics`.
 //
-// If `fullMatch` is true, all metrics from `reader` must be found in `expectedMetrics` vice versa.
-// Otherwise, only the metrics in `expectedMetrics` will be checked.
+// If `fullMatch` is true, all gathered metrics from `reader` must be found in `expectedMetrics` and vice versa.
+// Otherwise, `expectedMetrics` only need to be a subset of the gathered metrics.
 //
 // If `skipValAssert` is true, the AssertionFunc(s) will be skipped entirely.
 func assertOtelMetrics(

--- a/internal/beater/server_test.go
+++ b/internal/beater/server_test.go
@@ -440,7 +440,7 @@ func TestServerElasticsearchOutput(t *testing.T) {
 		w.Header().Set("X-Elastic-Product", "Elasticsearch")
 		// We must send a valid JSON response for the libbeat
 		// elasticsearch client to send bulk requests.
-		fmt.Fprintln(w, `{"version":{"number":"1.2.3"}}`)
+		_, _ = fmt.Fprintln(w, `{"version":{"number":"1.2.3"}}`)
 	})
 
 	done := make(chan struct{})
@@ -463,13 +463,14 @@ func TestServerElasticsearchOutput(t *testing.T) {
 	))
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 
+	const maxRequests = 10
 	srv := beatertest.NewServer(t, beatertest.WithMeterProvider(mp), beatertest.WithConfig(agentconfig.MustNewConfigFrom(map[string]interface{}{
 		"output.elasticsearch": map[string]interface{}{
 			"hosts":          []string{elasticsearchServer.URL},
 			"flush_interval": "1ms",
 			"backoff":        map[string]interface{}{"init": "1ms", "max": "1ms"},
 			"max_retries":    0,
-			"max_requests":   10,
+			"max_requests":   maxRequests,
 		},
 	})))
 
@@ -489,10 +490,13 @@ func TestServerElasticsearchOutput(t *testing.T) {
 		t.Fatal("timed out waiting for bulk request")
 	}
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
-		"elasticsearch.events.count":            5,
-		"elasticsearch.events.queued":           5,
-		"elasticsearch.bulk_requests.available": 9,
+	monitoringtest.ExpectContainOtelMetricsFunc(t, reader, map[string]monitoringtest.AssertionFunc{
+		"elasticsearch.events.count":  func(t *testing.T, actual any) bool { return actual.(int64) == 5 },
+		"elasticsearch.events.queued": func(t *testing.T, actual any) bool { return actual.(int64) == 5 },
+		"elasticsearch.bulk_requests.available": func(t *testing.T, actual any) bool {
+			// Available should be less than maxRequests since some will be used
+			return 0 < actual.(int64) && actual.(int64) < maxRequests
+		},
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/apm-server/issues/13606.

## How to test these changes

Run `go test ./... -run=^TestServerElasticsearchOutput$ -count 1000 -failfast`