### PR TITLE
fix: Wrong source in newly added Terraform tags

### DIFF
--- a/testing/smoke/main.tf
+++ b/testing/smoke/main.tf
@@ -11,7 +11,7 @@ terraform {
 provider "ec" {}
 
 module "tags" {
-  source  = "../infra/terraform/modules/tags"
+  source  = "../../infra/terraform/modules/tags"
   project = "apm-server"
 }
 


### PR DESCRIPTION
## Motivation/summary

Fix terraform changes introduced in https://github.com/elastic/apm-server/pull/15884.

See error in smoke test: https://github.com/elastic/apm-server/actions/runs/13645441445/job/38143422753
```
-> Running ./testing/smoke/basic-upgrade smoke tests for version 8.18...

Error: Unreadable module directory

Unable to evaluate directory symlink: lstat ../infra: no such file or
directory

Error: Unreadable module directory

The directory  could not be read for module "tags" at main.tf:13.
make: *** [Makefile:[31](https://github.com/elastic/apm-server/actions/runs/13649528881/job/38154767277#step:8:32)1: smoketest/run-version] Error 1
```

## How to test these changes

Run smoke test again.
