### PR TITLE
functionaltests: Parallelize tests

### DIFF
--- a/functionaltests/8_16_test.go
+++ b/functionaltests/8_16_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestUpgrade_8_15_4_to_8_16_0(t *testing.T) {
+	t.Parallel()
 	ecAPICheck(t)
 
 	tt := singleUpgradeTestCase{

--- a/functionaltests/9_0_test.go
+++ b/functionaltests/9_0_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestUpgrade_8_18_0_to_9_0_0(t *testing.T) {
+	t.Parallel()
 	ecAPICheck(t)
 
 	tt := singleUpgradeTestCase{


### PR DESCRIPTION
## Motivation/summary

Parallelize the functional tests so they can be done faster.
