### PR TITLE
benchmark: Align 8GB profiles worker size

### DIFF
--- a/testing/benchmark/system-profiles/8GB_NVMe-x1zone.tfvars
+++ b/testing/benchmark/system-profiles/8GB_NVMe-x1zone.tfvars
@@ -2,7 +2,7 @@ user_name = "USER"
 
 # APM bench
 
-worker_instance_type = "c6i.xlarge"
+worker_instance_type = "c6i.2xlarge"
 
 # Elastic Cloud
 

--- a/testing/benchmark/system-profiles/8GB_io2_6000iops-x1zone.tfvars
+++ b/testing/benchmark/system-profiles/8GB_io2_6000iops-x1zone.tfvars
@@ -2,7 +2,7 @@ user_name = "USER"
 
 # APM bench
 
-worker_instance_type = "c6i.xlarge"
+worker_instance_type = "c6i.2xlarge"
 
 # Elastic Cloud
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
8GBx1zone.tfvars already uses c6i.2xlarge. Update the corresponding 8GB
NVMe and io2 profiles to use c6i.2xlarge to avoid OOM.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follow up on #15733
