### PR TITLE
bench: Don't return error for agents SendBatchesInLoop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ x-logging: &default-logging
     max-size: "1g"
 services:
   elasticsearch:
-    # TODO: replace with a pinned version such as 9.0.0-aaaaaaaa-SNAPSHOT
     image: docker.elastic.co/elasticsearch/elasticsearch:9.1.0-7fa66b89-SNAPSHOT
     ports:
       - 9200:9200
@@ -20,7 +19,6 @@ services:
       interval: 1s
     environment:
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-      - _JAVA_OPTIONS # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
       - "network.host=0.0.0.0"
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
@@ -43,7 +41,6 @@ services:
     logging: *default-logging
 
   kibana:
-    # TODO: replace with a pinned version such as 9.0.0-aaaaaaaa-SNAPSHOT
     image: docker.elastic.co/kibana/kibana:9.1.0-7fa66b89-SNAPSHOT
     ports:
       - 5601:5601
@@ -63,7 +60,6 @@ services:
     logging: *default-logging
 
   metricbeat:
-    # TODO: replace with a pinned version such as 9.0.0-aaaaaaaa-SNAPSHOT
     image: docker.elastic.co/beats/metricbeat:9.1.0-7fa66b89-SNAPSHOT
     environment:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'

--- a/systemtest/benchtest/main.go
+++ b/systemtest/benchtest/main.go
@@ -30,13 +30,13 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"go.elastic.co/apm/v2/stacktrace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
 	"github.com/elastic/apm-perf/loadgen"
@@ -271,20 +271,20 @@ func warmup(agents int, duration time.Duration, url, token string) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
-	eg, ctx := errgroup.WithContext(ctx)
+
+	var wg sync.WaitGroup
+	wg.Add(agents)
 	for i := 0; i < agents; i++ {
-		eg.Go(func() error {
+		go func() {
+			defer wg.Done()
 			sendErr := h.SendBatchesInLoop(ctx)
 			if sendErr != nil && !errors.Is(sendErr, context.DeadlineExceeded) {
-				return sendErr
+				log.Printf("failed to send batches: %v", sendErr)
 			}
-			return nil
-		})
+		}()
 	}
 
-	if err = eg.Wait(); err != nil {
-		return err
-	}
+	wg.Wait()
 
 	ctx, cancel = context.WithTimeout(context.Background(), waitInactiveTimeout)
 	defer cancel()


### PR DESCRIPTION
## Motivation / Summary

Fix benchmark failure due to warmup, by reverting the change done to use `errgroup` for agents `SendBatchesInLoop`.
