### PR TITLE
fix: metrics interceptor concurrent map read write

### DIFF
--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -198,7 +198,7 @@ func TestMetrics_ConcurrentMapSafe(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for range 100 {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -73,8 +73,8 @@ func (m *monitoringMiddleware) getCounter(prefix, name string) metric.Int64Count
 		return met.(metric.Int64Counter)
 	}
 	nm, _ := m.meter.Int64Counter(name)
-	m.counters.LoadOrStore(name, nm)
-	return nm
+	met, _ := m.counters.LoadOrStore(name, nm)
+	return met.(metric.Int64Counter)
 }
 
 func (m *monitoringMiddleware) getHistogram(n string, opts ...metric.Int64HistogramOption) metric.Int64Histogram {
@@ -84,8 +84,8 @@ func (m *monitoringMiddleware) getHistogram(n string, opts ...metric.Int64Histog
 	}
 
 	nm, _ := m.meter.Int64Histogram(name, opts...)
-	m.histograms.LoadOrStore(name, nm)
-	return nm
+	met, _ := m.histograms.LoadOrStore(name, nm)
+	return met.(metric.Int64Histogram)
 }
 
 // MonitoringMiddleware returns a middleware that increases monitoring counters for collecting metrics


### PR DESCRIPTION
## Motivation/summary

Closes https://github.com/elastic/apm-server/issues/16178.

## How to test these changes

Run `go test -run=TestMetrics_ConcurrentMapSafe -race -v -count=10 -failfast ./...` and see that there are no fatal errors.
