### PR TITLE
smoke: Add missing patch in legacy major test

### DIFF
--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -12,19 +12,17 @@ fi
 VERSION_7=7.17
 if [[ "${1}" == "latest" ]]; then
     # SNAPSHOT version can only be upgraded to another SNAPSHOT version
-    get_latest_snapshot_for_version ${VERSION_7}
-    LATEST_VERSION_7=${LATEST_SNAPSHOT_VERSION}
-    ASSERTION_VERSION_7=${LATEST_SNAPSHOT_VERSION%-*} # strip -SNAPSHOT suffix
     get_latest_snapshot
+    LATEST_VERSION_7=$(echo "${VERSIONS}" | jq -r -c "map(select(. | startswith(\"${VERSION_7}\"))) | .[-1]")
+    ASSERTION_VERSION_7=${LATEST_SNAPSHOT_VERSION%-*} # strip -SNAPSHOT suffix
     LATEST_VERSION_8=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("8"))] | last')
     ASSERTION_VERSION_8=${LATEST_VERSION_8%-*} # strip -SNAPSHOT suffix
     LATEST_VERSION_9=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("9"))] | last')
     ASSERTION_VERSION_9=${LATEST_VERSION_9%-*} # strip -SNAPSHOT suffix
 else
-    get_latest_patch ${VERSION_7}
-    LATEST_VERSION_7=${VERSION_7}.${LATEST_PATCH}
-    ASSERTION_VERSION_7=${LATEST_VERSION_7}
     get_versions
+    LATEST_VERSION_7=$(echo "${VERSIONS}" | jq -r -c "map(select(. | startswith(\"${VERSION_7}\"))) | .[-1]")
+    ASSERTION_VERSION_7=${LATEST_VERSION_7}
     LATEST_VERSION_8=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("8"))] | last')
     ASSERTION_VERSION_8=${LATEST_VERSION_8}
     LATEST_VERSION_9=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("9"))] | last')

--- a/testing/smoke/lib.sh
+++ b/testing/smoke/lib.sh
@@ -23,6 +23,7 @@ get_versions() {
 
 get_latest_version() {
     local version
+    get_versions
     version=$(echo ${VERSIONS} | jq -r -c "max_by(. | select(. | startswith(\"${1}\")) | if endswith(\"-SNAPSHOT\") then .[:-9] else . end | split(\".\") | map(tonumber))")
     echo "${version}"
 }

--- a/testing/smoke/lib.sh
+++ b/testing/smoke/lib.sh
@@ -22,13 +22,20 @@ get_versions() {
 }
 
 get_latest_version() {
+    if [[ -z "${VERSIONS}" ]]; then
+        echo "-> Version not set, call get_versions first"
+        return 1
+    fi
     local version
-    get_versions
     version=$(echo ${VERSIONS} | jq -r -c "max_by(. | select(. | startswith(\"${1}\")) | if endswith(\"-SNAPSHOT\") then .[:-9] else . end | split(\".\") | map(tonumber))")
     echo "${version}"
 }
 
 get_latest_patch() {
+    if [[ -z "${1}" ]]; then
+        echo "-> Version not set"
+        return 1
+    fi
     LATEST_PATCH=$(get_latest_version "${1}" | cut -d '.' -f3)
 }
 


### PR DESCRIPTION
## Motivation/summary

Caused by https://github.com/elastic/apm-server/pull/16131.

Smoke test failed, missing patch:
```
-> Running 7.17. standalone to 8.18.0 standalone to 9.0.0 standalone to 9.0.0 managed
```

## How to test these changes

Run `smoke-test-ess` with this branch: https://github.com/elastic/apm-server/actions/runs/13849821727.
