### PR TITLE
smoke: Temporarily disable failing 9.0 smoke test upgrade in legacy major

### DIFF
--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -60,20 +60,22 @@ healthcheck 1
 send_events
 data_stream_assertions "${ASSERTION_VERSION_8}"
 
-# Version 9 (if exists)
 MANAGED_VERSION="${LATEST_VERSION_8}"
 ASSERTION_MANAGED_VERSION="${ASSERTION_VERSION_8}"
-if [[ -n ${LATEST_VERSION_9} ]]; then
-    cleanup_tfvar
-    append_tfvar "stack_version" "${LATEST_VERSION_9}"
-    append_tfvar "integrations_server" ${INTEGRATIONS_SERVER}
-    terraform_apply
-    healthcheck 1
-    send_events
-    data_stream_assertions "${ASSERTION_VERSION_9}"
-    MANAGED_VERSION="${LATEST_VERSION_9}"
-    ASSERTION_MANAGED_VERSION="${ASSERTION_VERSION_9}"
-fi
+
+##### Disabled for now because both 9.0.0 and 9.1.0-SNAPSHOT are failing!
+# Version 9 (if exists)
+#if [[ -n ${LATEST_VERSION_9} ]]; then
+#    cleanup_tfvar
+#    append_tfvar "stack_version" "${LATEST_VERSION_9}"
+#    append_tfvar "integrations_server" ${INTEGRATIONS_SERVER}
+#    terraform_apply
+#    healthcheck 1
+#    send_events
+#    data_stream_assertions "${ASSERTION_VERSION_9}"
+#    MANAGED_VERSION="${LATEST_VERSION_9}"
+#    ASSERTION_MANAGED_VERSION="${ASSERTION_VERSION_9}"
+#fi
 
 upgrade_managed "${MANAGED_VERSION}"
 healthcheck 1

--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -18,8 +18,6 @@ if [[ "${1}" == "latest" ]]; then
     get_latest_snapshot
     LATEST_VERSION_8=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("8"))] | last')
     ASSERTION_VERSION_8=${LATEST_VERSION_8%-*} # strip -SNAPSHOT suffix
-    LATEST_VERSION_9=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("9"))] | last')
-    ASSERTION_VERSION_9=${LATEST_VERSION_9%-*} # strip -SNAPSHOT suffix
 else
     get_latest_patch ${VERSION_7}
     LATEST_VERSION_7=${VERSION_7}.${LATEST_PATCH}
@@ -27,8 +25,6 @@ else
     get_versions
     LATEST_VERSION_8=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("8"))] | last')
     ASSERTION_VERSION_8=${LATEST_VERSION_8}
-    LATEST_VERSION_9=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("9"))] | last')
-    ASSERTION_VERSION_9=${LATEST_VERSION_9}
 fi
 
 if [[ -n ${LATEST_VERSION_9} ]]; then
@@ -62,20 +58,6 @@ data_stream_assertions "${ASSERTION_VERSION_8}"
 
 MANAGED_VERSION="${LATEST_VERSION_8}"
 ASSERTION_MANAGED_VERSION="${ASSERTION_VERSION_8}"
-
-##### Disabled for now because both 9.0.0 and 9.1.0-SNAPSHOT are failing!
-# Version 9 (if exists)
-#if [[ -n ${LATEST_VERSION_9} ]]; then
-#    cleanup_tfvar
-#    append_tfvar "stack_version" "${LATEST_VERSION_9}"
-#    append_tfvar "integrations_server" ${INTEGRATIONS_SERVER}
-#    terraform_apply
-#    healthcheck 1
-#    send_events
-#    data_stream_assertions "${ASSERTION_VERSION_9}"
-#    MANAGED_VERSION="${LATEST_VERSION_9}"
-#    ASSERTION_MANAGED_VERSION="${ASSERTION_VERSION_9}"
-#fi
 
 upgrade_managed "${MANAGED_VERSION}"
 healthcheck 1


### PR DESCRIPTION
## Motivation/summary

Closes https://github.com/elastic/apm-server/issues/16180.

Unfortunately, tests for legacy 9.x are failing and it's unlikely we will be able to fix them using the current smoke tests. Disabling the upgrade for now. Instead of 7.x -> 8.x -> 9.x, we will simply do 7.x -> 8.x for now.

We will follow up with https://github.com/elastic/apm-server/issues/16199, by using functional tests to perform the test instead. 
