### PR TITLE
functionaltests: Fix terraform source being wrong after copy

### DIFF
--- a/functionaltests/infra/terraform/main.tf
+++ b/functionaltests/infra/terraform/main.tf
@@ -1,5 +1,5 @@
 module "ec_deployment" {
-  source = "../../../testing/infra/terraform/modules/ec_deployment"
+  source = "../../testing/infra/terraform/modules/ec_deployment"
   region = var.ec_region
 
   deployment_template    = var.ec_deployment_template

--- a/functionaltests/infra/terraform/tags.tf
+++ b/functionaltests/infra/terraform/tags.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 module "tags" {
-  source = "../../../testing/infra/terraform/modules/tags"
+  source = "../../testing/infra/terraform/modules/tags"
   # use the convention for team/shared owned resources if we are running in CI. 
   # assume this is an individually owned resource otherwise. 
   project = local.project


### PR DESCRIPTION
## Motivation/summary

The terraform source currently points to nowhere. After copying, it is one level up as compared to when its in `infra/terraform`.

## How to test these changes

Run functionaltests with this branch: https://github.com/elastic/apm-server/actions/runs/13899696031.
