### PR TITLE
smoke: Fix 9.0.0 assertion fail and legacy major typo

### DIFF
--- a/testing/smoke/basic-upgrade/test.sh
+++ b/testing/smoke/basic-upgrade/test.sh
@@ -3,25 +3,25 @@
 set -eo pipefail
 
 # Load common lib
-. $(git rev-parse --show-toplevel)/testing/smoke/lib.sh
+. "$(git rev-parse --show-toplevel)/testing/smoke/lib.sh"
 
 # Get all the versions from the current region.
 get_versions
 
 VERSION=${1}
 if [[ -z ${VERSION} ]] || [[ "${VERSION}" == "latest" ]]; then
-    VERSION=$(echo ${VERSIONS} | jq -r 'last')
-    echo "-> unspecified version, using $(echo ${VERSION} | cut -d '.' -f1-2)"
+    VERSION=$(echo "${VERSIONS}" | jq -r 'last')
+    echo "-> unspecified version, using $(echo "${VERSION}" | cut -d '.' -f1-2)"
 fi
-MAJOR_VERSION=$(echo ${VERSION} | cut -d '.' -f1 )
-MINOR_VERSION=$(echo ${VERSION} | cut -d '.' -f2 )
+MAJOR_VERSION=$(echo "${VERSION}" | cut -d '.' -f1 )
+MINOR_VERSION=$(echo "${VERSION}" | cut -d '.' -f2 )
 
 if [[ ${MAJOR_VERSION} -eq 7 ]]; then
     ASSERT_EVENTS_FUNC=legacy_assertions
     INTEGRATIONS_SERVER=false
     get_latest_patch "${MAJOR_VERSION}.${MINOR_VERSION}"
     LATEST_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}.${LATEST_PATCH}
-    PREV_LATEST_VERSION=$(echo ${MAJOR_VERSION}.${MINOR_VERSION}.$(( ${LATEST_PATCH} -1 )))
+    PREV_LATEST_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.$(( LATEST_PATCH - 1 ))"
 elif [[ ${MAJOR_VERSION} -eq 8 ]] || [[ ${MAJOR_VERSION} -eq 9 ]]; then
     ASSERT_EVENTS_FUNC=data_stream_assertions
     INTEGRATIONS_SERVER=true
@@ -31,10 +31,10 @@ elif [[ ${MAJOR_VERSION} -eq 8 ]] || [[ ${MAJOR_VERSION} -eq 9 ]]; then
 
     # when the minor is 0, we want to fetch the latest patch of the previous major
     if [[ ${MINOR_VERSION} -eq 0 ]]; then
-        PREV_MAJOR=$(( ${MAJOR_VERSION} -1 ))
+        PREV_MAJOR=$(( MAJOR_VERSION - 1 ))
         PREV_LATEST_VERSION=$(get_latest_version "${PREV_MAJOR}")
     else
-      PREV_MINOR=$(( ${MINOR_VERSION} -1 ))
+      PREV_MINOR=$(( MINOR_VERSION - 1 ))
       get_latest_patch "${MAJOR_VERSION}.${PREV_MINOR}"
       PREV_LATEST_VERSION=${MAJOR_VERSION}.${PREV_MINOR}.${LATEST_PATCH}
     fi
@@ -49,6 +49,17 @@ if [ "${LATEST_VERSION}" == "${PREV_LATEST_VERSION}" ]; then
     exit 5
 fi
 
+PREV_LATEST_OBSERVER_VERSION="${PREV_LATEST_VERSION}"
+if [[ ${PREV_LATEST_OBSERVER_VERSION} == "9.0.0" ]]; then
+    # Temporary hack due to 9.0.0 versioned as release candidate
+    PREV_LATEST_OBSERVER_VERSION="9.0.0-rc1"
+fi
+LATEST_OBSERVER_VERSION="${LATEST_VERSION}"
+if [[ ${LATEST_OBSERVER_VERSION} == "9.0.0" ]]; then
+    # Temporary hack due to 9.0.0 versioned as release candidate
+    LATEST_OBSERVER_VERSION="9.0.0-rc1"
+fi
+
 echo "-> Running basic upgrade smoke test for version ${VERSION}"
 
 if [[ -z ${SKIP_DESTROY} ]]; then
@@ -56,18 +67,18 @@ if [[ -z ${SKIP_DESTROY} ]]; then
 fi
 
 cleanup_tfvar
-append_tfvar "stack_version" ${PREV_LATEST_VERSION}
+append_tfvar "stack_version" "${PREV_LATEST_VERSION}"
 append_tfvar "integrations_server" ${INTEGRATIONS_SERVER}
 terraform_apply
 healthcheck 1
 send_events
-${ASSERT_EVENTS_FUNC} ${STACK_VERSION}
+${ASSERT_EVENTS_FUNC} "${PREV_LATEST_OBSERVER_VERSION}"
 
 echo "-> Upgrading APM Server from ${STACK_VERSION} to ${LATEST_VERSION}"
 cleanup_tfvar
-append_tfvar "stack_version" ${LATEST_VERSION}
+append_tfvar "stack_version" "${LATEST_VERSION}"
 append_tfvar "integrations_server" ${INTEGRATIONS_SERVER}
 terraform_apply
 healthcheck 1
 send_events
-${ASSERT_EVENTS_FUNC} ${STACK_VERSION}
+${ASSERT_EVENTS_FUNC} "${LATEST_OBSERVER_VERSION}"

--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -14,7 +14,7 @@ if [[ "${1}" == "latest" ]]; then
     # SNAPSHOT version can only be upgraded to another SNAPSHOT version
     get_latest_snapshot
     LATEST_VERSION_7=$(echo "${VERSIONS}" | jq -r -c "map(select(. | startswith(\"${VERSION_7}\"))) | .[-1]")
-    ASSERTION_VERSION_7=${LATEST_SNAPSHOT_VERSION%-*} # strip -SNAPSHOT suffix
+    ASSERTION_VERSION_7=${LATEST_VERSION_7%-*} # strip -SNAPSHOT suffix
     LATEST_VERSION_8=$(echo "${VERSIONS}" | jq -r '[.[] | select(. | startswith("8"))] | last')
     ASSERTION_VERSION_8=${LATEST_VERSION_8%-*} # strip -SNAPSHOT suffix
 else
@@ -25,11 +25,7 @@ else
     ASSERTION_VERSION_8=${LATEST_VERSION_8}
 fi
 
-if [[ -n ${LATEST_VERSION_9} ]]; then
-    echo "-> Running ${LATEST_VERSION_7} standalone to ${LATEST_VERSION_8} standalone to ${LATEST_VERSION_9} standalone to ${LATEST_VERSION_9} managed"
-else
-    echo "-> Running ${LATEST_VERSION_7} standalone to ${LATEST_VERSION_8} standalone to ${LATEST_VERSION_8} managed"
-fi
+echo "-> Running ${LATEST_VERSION_7} standalone to ${LATEST_VERSION_8} standalone to ${LATEST_VERSION_8} managed"
 
 if [[ -z ${SKIP_DESTROY} ]]; then
     trap "terraform_destroy" EXIT


### PR DESCRIPTION
## Motivation/summary

Resolves https://github.com/elastic/apm-server/issues/16179.

Also fixes a typo in `legacy-standalone-major-managed` causing assertion failure.

Follow up: https://github.com/elastic/apm-server/issues/16277.

## How to test these changes

Run `smoke-test-ess` with this branch: https://github.com/elastic/apm-server/actions/runs/13917697551.
