### PR TITLE
functionaltests: Disable QA env in functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         environment:
-          - 'qa'
           - 'pro'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Motivation/summary

The functional tests in CI has been failing intermittently in QA multiple times. We should disable it for now, since running on production CFT should good enough.

```
Received unexpected error:
    cannot run generator: Post "<url>": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

```
Received unexpected error:
    cannot retrieve APM doc count: status: 404, failed: [shard_not_found_exception], reason: no shard copies found [.ds-metrics-apm.service_destination.1m-default-2025.03.19-000001][0]
```

```
Received unexpected error:
    cannot run generator: unexpected server error: 502
```

```
failed tracking create progress: 2 errors occurred:
    * found deployment plan errors: deployment [1b2206bb351a68259c067fa2e3a9277e] - [integrations_server][6ba90b69f29646428035c5a1fd9febb8]: caught error: "Plan change failed: Plan aborted by deletion of pending plan"
```

## How to test

Run functionaltests in workflow using this branch: https://github.com/elastic/apm-server/actions/runs/13967459712.