### PR TITLE
functionaltests: Add BC tests

### DIFF
--- a/functionaltests/8_16_test.go
+++ b/functionaltests/8_16_test.go
@@ -21,54 +21,20 @@ import (
 	"context"
 	"testing"
 
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+
 	"github.com/elastic/apm-server/functionaltests/internal/esclient"
 	"github.com/elastic/apm-server/functionaltests/internal/kbclient"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 )
 
-// In 8.15, the data stream management was migrated from
-// ILM to DSL. However, a bug was introduced, causing data
-// streams to be unmanaged.
-// See https://github.com/elastic/apm-server/issues/13898.
-//
-// It was fixed by defaulting data stream management to DSL,
-// and eventually reverted back to ILM in 8.17.
-//
-// Therefore, data streams created in 8.15 and 8.16 are
-// managed by DSL instead of ILM.
-
-func TestUpgrade_8_15_to_8_16(t *testing.T) {
+func TestUpgrade_8_15_to_8_16_Snapshot(t *testing.T) {
 	t.Parallel()
-	skipNonActiveMajorMinorVersion(t, "8.16")
 
-	tt := singleUpgradeTestCase{
-		fromVersion: getLatestSnapshot(t, "8.15"),
-		toVersion:   getLatestSnapshot(t, "8.16"),
-		checkPreUpgradeAfterIngest: checkDatastreamWant{
-			Quantity:         8,
-			PreferIlm:        false,
-			DSManagedBy:      managedByDSL,
-			IndicesPerDs:     1,
-			IndicesManagedBy: []string{managedByDSL},
-		},
-		checkPostUpgradeBeforeIngest: checkDatastreamWant{
-			Quantity:         8,
-			PreferIlm:        false,
-			DSManagedBy:      managedByDSL,
-			IndicesPerDs:     1,
-			IndicesManagedBy: []string{managedByDSL},
-		},
-		// Verify lazy rollover happened, i.e. 2 indices per data stream.
-		// Check data streams are managed by DSL since they are created after 8.15.0.
-		checkPostUpgradeAfterIngest: checkDatastreamWant{
-			Quantity:         8,
-			PreferIlm:        false,
-			DSManagedBy:      managedByDSL,
-			IndicesPerDs:     2,
-			IndicesManagedBy: []string{managedByDSL, managedByDSL},
-		},
-
-		apmErrorLogsIgnored: []types.Query{
+	runBasicUpgradeLazyRolloverDSLTest(
+		t,
+		getLatestSnapshot(t, "8.15"),
+		getLatestSnapshot(t, "8.16"),
+		[]types.Query{
 			tlsHandshakeError,
 			esReturnedUnknown503,
 			preconditionFailed,
@@ -78,19 +44,38 @@ func TestUpgrade_8_15_to_8_16(t *testing.T) {
 			// TODO: remove once fixed
 			populateSourcemapFetcher403,
 		},
-	}
+	)
+}
 
-	tt.Run(t)
+func TestUpgrade_8_15_to_8_16_BC(t *testing.T) {
+	t.Parallel()
+
+	runBasicUpgradeLazyRolloverDSLTest(
+		t,
+		getLatestVersion(t, "8.15"),
+		getBCVersionOrSkip(t, "8.16"),
+		[]types.Query{
+			tlsHandshakeError,
+			esReturnedUnknown503,
+			preconditionFailed,
+			populateSourcemapServerShuttingDown,
+			refreshCacheCtxDeadline,
+			refreshCacheCtxCanceled,
+			// TODO: remove once fixed
+			populateSourcemapFetcher403,
+		},
+	)
 }
 
 func TestUpgrade_8_14_to_8_16_Reroute(t *testing.T) {
 	t.Parallel()
-	skipNonActiveMajorMinorVersion(t, "8.16")
+	toVersion := getLatestSnapshot(t, "8.16")
+	skipNonActiveVersion(t, toVersion)
 
 	rerouteNamespace := "rerouted"
 	tt := singleUpgradeTestCase{
 		fromVersion:         getLatestSnapshot(t, "8.14"),
-		toVersion:           getLatestSnapshot(t, "8.16"),
+		toVersion:           toVersion,
 		dataStreamNamespace: rerouteNamespace,
 		setupFn: func(t *testing.T, ctx context.Context, esc *esclient.Client, _ *kbclient.Client) error {
 			t.Log("create reroute processors")

--- a/functionaltests/9_0_test.go
+++ b/functionaltests/9_0_test.go
@@ -23,13 +23,30 @@ import (
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 )
 
-func TestUpgrade_8_18_to_9_0(t *testing.T) {
+func TestUpgrade_8_18_to_9_0_Snapshot(t *testing.T) {
 	t.Parallel()
 
 	runBasicUpgradeILMTest(
 		t,
-		"8.18",
-		"9.0",
+		getLatestSnapshot(t, "8.18"),
+		getLatestSnapshot(t, "9.0"),
+		[]types.Query{
+			tlsHandshakeError,
+			esReturnedUnknown503,
+			refreshCache503,
+			// TODO: remove once fixed
+			populateSourcemapFetcher403,
+		},
+	)
+}
+
+func TestUpgrade_8_18_to_9_0_BC(t *testing.T) {
+	t.Parallel()
+
+	runBasicUpgradeILMTest(
+		t,
+		getLatestVersion(t, "8.18"),
+		getBCVersionOrSkip(t, "9.0"),
 		[]types.Query{
 			tlsHandshakeError,
 			esReturnedUnknown503,

--- a/functionaltests/basic_upgrade_test.go
+++ b/functionaltests/basic_upgrade_test.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package functionaltests
+
+import (
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+
+	"github.com/elastic/apm-server/functionaltests/internal/ecclient"
+)
+
+// runBasicUpgradeILMTest performs a basic upgrade test from `fromVersion` to
+// `toVersion`. The test assumes that all data streams are using Index
+// Lifecycle Management (ILM) instead of Data Stream Lifecycle Management
+// (DSL), which should be the case for most recent APM data streams.
+func runBasicUpgradeILMTest(
+	t *testing.T,
+	fromVersion ecclient.StackVersion,
+	toVersion ecclient.StackVersion,
+	apmErrorLogsIgnored []types.Query,
+) {
+	skipNonActiveVersion(t, toVersion)
+
+	testCase := singleUpgradeTestCase{
+		fromVersion: fromVersion,
+		toVersion:   toVersion,
+		checkPreUpgradeAfterIngest: checkDatastreamWant{
+			Quantity:         8,
+			PreferIlm:        true,
+			DSManagedBy:      managedByILM,
+			IndicesPerDs:     1,
+			IndicesManagedBy: []string{managedByILM},
+		},
+		checkPostUpgradeBeforeIngest: checkDatastreamWant{
+			Quantity:         8,
+			PreferIlm:        true,
+			DSManagedBy:      managedByILM,
+			IndicesPerDs:     1,
+			IndicesManagedBy: []string{managedByILM},
+		},
+		checkPostUpgradeAfterIngest: checkDatastreamWant{
+			Quantity:         8,
+			PreferIlm:        true,
+			DSManagedBy:      managedByILM,
+			IndicesPerDs:     1,
+			IndicesManagedBy: []string{managedByILM},
+		},
+		apmErrorLogsIgnored: apmErrorLogsIgnored,
+	}
+
+	testCase.Run(t)
+}
+
+// runBasicUpgradeLazyRolloverDSLTest performs a basic upgrade test from
+// `fromVersion` to `toVersion`. The test assumes that all data streams are
+// using Data Stream Lifecycle Management (DSL) instead of Index Lifecycle
+// Management (ILM).
+//
+// In 8.15, the data stream management was migrated from ILM to DSL.
+// However, a bug was introduced, causing data streams to be unmanaged.
+// See https://github.com/elastic/apm-server/issues/13898.
+//
+// It was fixed by defaulting data stream management to DSL, and eventually
+// reverted back to ILM in 8.17. Therefore, data streams created in 8.15 and
+// 8.16 are managed by DSL instead of ILM.
+func runBasicUpgradeLazyRolloverDSLTest(
+	t *testing.T,
+	fromVersion ecclient.StackVersion,
+	toVersion ecclient.StackVersion,
+	apmErrorLogsIgnored []types.Query,
+) {
+	skipNonActiveVersion(t, toVersion)
+
+	testCase := singleUpgradeTestCase{
+		fromVersion: fromVersion,
+		toVersion:   toVersion,
+		checkPreUpgradeAfterIngest: checkDatastreamWant{
+			Quantity:         8,
+			PreferIlm:        false,
+			DSManagedBy:      managedByDSL,
+			IndicesPerDs:     1,
+			IndicesManagedBy: []string{managedByDSL},
+		},
+		checkPostUpgradeBeforeIngest: checkDatastreamWant{
+			Quantity:         8,
+			PreferIlm:        false,
+			DSManagedBy:      managedByDSL,
+			IndicesPerDs:     1,
+			IndicesManagedBy: []string{managedByDSL},
+		},
+		// Verify lazy rollover happened, i.e. 2 indices per data stream.
+		// Check data streams are managed by DSL.
+		checkPostUpgradeAfterIngest: checkDatastreamWant{
+			Quantity:         8,
+			PreferIlm:        false,
+			DSManagedBy:      managedByDSL,
+			IndicesPerDs:     2,
+			IndicesManagedBy: []string{managedByDSL, managedByDSL},
+		},
+		apmErrorLogsIgnored: apmErrorLogsIgnored,
+	}
+
+	testCase.Run(t)
+}

--- a/functionaltests/single_upgrade_test.go
+++ b/functionaltests/single_upgrade_test.go
@@ -63,7 +63,7 @@ type singleUpgradeTestCase struct {
 
 func (tt singleUpgradeTestCase) Run(t *testing.T) {
 	if tt.dataStreamNamespace == "" {
-		tt.dataStreamNamespace = defaultNamespace
+		tt.dataStreamNamespace = "default"
 	}
 
 	start := time.Now()

--- a/functionaltests/utils_test.go
+++ b/functionaltests/utils_test.go
@@ -26,21 +26,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/apm-server/functionaltests/internal/ecclient"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 
 	"github.com/elastic/apm-server/functionaltests/internal/esclient"
 	"github.com/elastic/apm-server/functionaltests/internal/kbclient"
 	"github.com/elastic/apm-server/functionaltests/internal/terraform"
 )
-
-// getLatestSnapshot retrieves the latest snapshot version for the version prefix.
-func getLatestSnapshot(t *testing.T, prefix string) ecclient.StackVersion {
-	t.Helper()
-	version, ok := fetchedSnapshots.LatestFor(prefix)
-	require.True(t, ok, "no version with prefix '%s' found in EC region %s", prefix, regionFrom(*target))
-	return version
-}
 
 // createAPMAPIKey creates an Elasticsearch API key with the test name.
 func createAPMAPIKey(t *testing.T, ctx context.Context, esc *esclient.Client) string {


### PR DESCRIPTION
## Motivation/summary

This PR introduces functional tests for build candidate (BC) versions. The previous idea of using a single `TestUpgradeBC` test to run tests for all BC versions does not work, as each version may have their own caveats, e.g. DSL vs ILM, lazy rollover, different ignored APM error logs etc.

Note: `TestUpgrade_8_14_to_8_16_Reroute` is not changed since subsequent PR to introduce reroute tests for all versions will replace it.

## How to test these changes

Run functionaltests workflow with this branch: https://github.com/elastic/apm-server/actions/runs/13989686769.
