### PR TITLE
ci: update changelog release automation

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -6,15 +6,15 @@ navigation_title: "Breaking changes"
 
 Breaking changes can impact your Elastic applications, potentially disrupting normal operations. Before you upgrade, carefully review the Elastic APM breaking changes and take the necessary steps to mitigate any issues. To learn how to upgrade, check [Upgrade](docs-content://deploy-manage/upgrade.md).
 
-% ## Next version [next-version]
+## Next version [next-version]
 % **Release date:** Month day, year
 
 % ::::{dropdown} Title of breaking change
 % Description of the breaking change.
 % For more information, check [#PR-number]({{apm-pull}}PR-number).
-
+%
 % **Impact**<br> Impact of the breaking change.
-
+%
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 

--- a/release.mk
+++ b/release.mk
@@ -75,28 +75,6 @@ endif
 #######################
 ## Templates
 #######################
-## Changelog template
-define CHANGELOG_TMPL
-[[release-notes-head]]
-== APM version HEAD
-
-https://github.com/elastic/apm-server/compare/$(RELEASE_BRANCH)\...$(CHANGELOG_BRANCH)[View commits]
-
-[float]
-==== Breaking Changes
-
-[float]
-==== Bug fixes
-
-[float]
-==== Deprecations
-
-[float]
-==== Intake API Changes
-
-[float]
-==== Added
-endef
 
 ## Changelog template for new minors
 define CHANGELOG_MINOR_TMPL
@@ -138,7 +116,7 @@ minor-release:
 # Target main and use the backport strategy
 	$(MAKE) create-branch NAME=changelog-$(RELEASE_BRANCH) BASE=main
 	$(MAKE) update-changelog VERSION=$(RELEASE_BRANCH)
-	$(MAKE) rename-changelog VERSION=$(RELEASE_BRANCH)
+	$(MAKE) common-changelog
 	$(MAKE) create-commit COMMIT_MESSAGE="docs: Update changelogs for $(RELEASE_BRANCH) release"
 
 # NOTE: as long as 8.x is the branch to run releases, then we update mergify
@@ -161,7 +139,7 @@ endif
 #endif
 	$(MAKE) update-version VERSION=$(NEXT_PROJECT_MINOR_VERSION)
 	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update version $(NEXT_PROJECT_MINOR_VERSION)"
-	$(MAKE) rename-changelog VERSION=$(RELEASE_BRANCH)
+	$(MAKE) common-changelog
 	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update changelogs for $(RELEASE_BRANCH) release"
 
 	@echo "INFO: Push changes to $(PROJECT_OWNER)/apm-server and create the relevant Pull Requests"
@@ -204,22 +182,6 @@ patch-release:
 ############################################
 ## Internal make goals to bump versions
 ############################################
-
-# Rename changelog file to generate something similar to https://github.com/elastic/apm-server/pull/12172
-.PHONY: rename-changelog
-export CHANGELOG_TMPL
-rename-changelog: VERSION=$${VERSION}
-rename-changelog:
-	$(MAKE) common-changelog
-	@echo ">> rename-changelog"
-	echo "$$CHANGELOG_TMPL" > changelogs/head.asciidoc
-	@if ! grep -q 'apm-release-notes-$(VERSION)' CHANGELOG.asciidoc ; then \
-		awk "NR==2{print \"* <<apm-release-notes-$(VERSION)>>\"}1" CHANGELOG.asciidoc > CHANGELOG.asciidoc.new; \
-		mv CHANGELOG.asciidoc.new CHANGELOG.asciidoc ; \
-	fi
-	@if ! grep -q '$(VERSION).asciidoc' CHANGELOG.asciidoc ; then \
-		$(SED) -E -e 's#(head.asciidoc\[\])#\1\ninclude::.\/changelogs\/$(VERSION).asciidoc[]#g' CHANGELOG.asciidoc; \
-	fi
 
 # Update changelog file to generate something similar to https://github.com/elastic/apm-server/pull/12220
 .PHONY: update-changelog

--- a/release.mk
+++ b/release.mk
@@ -73,24 +73,6 @@ ifeq ($(RELEASE_TYPE),major)
 endif
 
 #######################
-## Templates
-#######################
-
-## Changelog template for new minors
-define CHANGELOG_MINOR_TMPL
-[[apm-release-notes-$(RELEASE_BRANCH)]]
-== APM version $(RELEASE_BRANCH)
-* <<apm-release-notes-$(RELEASE_BRANCH).0>>
-
-[float]
-[[apm-release-notes-$(RELEASE_BRANCH).0]]
-=== APM version $(RELEASE_BRANCH).0
-
-https://github.com/elastic/apm-server/compare/v$(CURRENT_RELEASE)\...v$(RELEASE_BRANCH).0[View commits]
-
-endef
-
-#######################
 ## Public make goals
 #######################
 
@@ -187,9 +169,8 @@ patch-release:
 .PHONY: update-changelog
 update-changelog: VERSION=$${VERSION}
 update-changelog:
-	$(MAKE) common-changelog
 	@echo ">> update-changelog"
-	$(SED) 's#head#$(VERSION)#g' CHANGELOG.asciidoc
+	bash ./tools/scripts/changelog.sh $(VERSION)
 
 # Common changelog file steps
 .PHONY: common-changelog

--- a/tools/scripts/changelog.sh
+++ b/tools/scripts/changelog.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/bash
+#
+# This script:
+# - updates the 'Next version' in breaking-changes.md to match the specified version
+# - add back the 'Next version' section, with template
+
+set -eou pipefail
+
+# Ugly but needed for MacOS. Sed on MacOS fails when calling sed --help with an illegal argument exception.
+# Exploit this to check if the user has a bad sed version and exit early.
+if ! sed --help >/dev/null 2>&1; then
+  echo "sed does not look like GNU sed. Are you running on MacOS perhaps? Install GNU sed, make it so you can call it with sed and retry"
+  exit 8
+fi
+
+updateFile() {
+  local file
+  file=$1
+
+  newfile="newfile.md"
+
+  # get the line where we will introduce back the next version section
+  LN=$(grep -n "## Next version" "$file" | head -1 | grep -Eo '^[^:]+')
+  # replace next version with actual version (with HTTP anchor)
+  anchor=$(echo "$VERSION" | tr . -)
+
+  # create the new file content
+  # take lines up to next version
+  head -n "$(($LN - 1))" "$file" > "$newfile"
+  # add back the next version section
+  cat >> "$newfile" << 'EOS'
+## Next version [next-version]
+% **Release date:** Month day, year
+
+% ::::{dropdown} Title of breaking change
+% Description of the breaking change.
+% For more information, check [#PR-number]({{apm-pull}}PR-number).
+%
+% **Impact**<br> Impact of the breaking change.
+%
+% **Action**<br> Steps for mitigating deprecation impact.
+% ::::
+
+EOS
+  # add the rest of the file, replace next section with version
+  tail -n+$LN "$file" | \
+    sed "s|## Next version.*|## $VERSION [$anchor]|g" /dev/stdin >> "$newfile"
+  # replace breaking change file with new content
+  mv "$newfile" "$file"
+}
+
+updateBreakingChanges() {
+  updateFile "./docs/release-notes/breaking-changes.md"
+}
+
+updateDeprecations() {
+  updateFile "./docs/release-notes/deprecations.md"
+}
+
+updateIndex() {
+  file=./docs/release-notes/index.md
+  newfile="newfile.md"
+
+  # get the line where we will introduce back the next version section
+  LN=$(grep -n "## version.next" "$file" | head -1 | grep -Eo '^[^:]+')
+  # replace next version with actual version (with HTTP anchor)
+  anchor=$(echo "$VERSION" | tr . -)
+
+  # create the new file content
+  # take lines up to next version
+  head -n "$(($LN - 1))" "$file" > "$newfile"
+  # add back the next version section
+  cat >> "$newfile" << 'EOS'
+## version.next [elastic-apm-next-release-notes]
+% **Release date:** Month day, year
+
+### Features and enhancements [elastic-apm-next-features-enhancements]
+
+%* 1 sentence describing the change. ([#PR number](https://github.com/elastic/apm-server/pull/PR number))
+
+### Fixes [elastic-apm-next-fixes]
+
+%* 1 sentence describing the change. ([#PR number](https://github.com/elastic/apm-server/pull/PR number))
+
+EOS
+  # add the rest of the file, replace next section with version
+  tail -n+$LN "$file" | \
+    sed "s|## version.next.*|## $VERSION [$anchor]|g" /dev/stdin >> "$newfile"
+  # replace breaking change file with new content
+  mv "$newfile" "$file"
+}
+
+
+VERSION=${1:-}
+
+test -z VERSION && {
+  echo "VERSION is required"
+  exit 2
+}
+
+echo ">> updating changelog for $VERSION"
+
+updateBreakingChanges
+updateDeprecations
+updateIndex


### PR DESCRIPTION
## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

We recently changed how we manage the changelog. Our release automation needs to be updated.

See https://github.com/elastic/apm-server/issues/16181

In draft as I'm still learning how things will play out. What I know so far:
- docs will be released from `main`
- older doc is not affected: this means our release workflow will need to be run from older branches (or we should create a new release workflow?)
- the content is broken down in multiple files but is not broken down by version, all release notes will be added to the same files (this may be revisited if automation becomes too complex, but does not seem to be the case)
- a "Next version" section will be available on top of each page
- backports are not expected, may still be done to ease backporting other changes

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

The best way is to run them locally in a Linux context (for those using MacOS).

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
https://github.com/elastic/apm-server/issues/16181
