### PR TITLE
Remove goja replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -264,5 +264,3 @@ tool (
 	gotest.tools/gotestsum
 	honnef.co/go/tools/cmd/staticcheck
 )
-
-replace github.com/dop251/goja => github.com/elastic/goja v0.0.0-20190128172624-dd2ac4456e20 // pin to version used by beats


### PR DESCRIPTION

## Motivation/summary

Replace directive for `goja` no longer required after [this PR](https://github.com/elastic/apm-server/pull/16344/files#r2009436501).