### PR TITLE
functionaltests: Fix post-upgrade assertion

### DIFF
--- a/functionaltests/basic_upgrade_test.go
+++ b/functionaltests/basic_upgrade_test.go
@@ -41,21 +41,21 @@ func runBasicUpgradeILMTest(
 	testCase := singleUpgradeTestCase{
 		fromVersion: fromVersion,
 		toVersion:   toVersion,
-		checkPreUpgradeAfterIngest: checkDatastreamWant{
+		checkPreUpgradeAfterIngest: checkDataStreamWant{
 			Quantity:         8,
 			PreferIlm:        true,
 			DSManagedBy:      managedByILM,
 			IndicesPerDs:     1,
 			IndicesManagedBy: []string{managedByILM},
 		},
-		checkPostUpgradeBeforeIngest: checkDatastreamWant{
+		checkPostUpgradeBeforeIngest: checkDataStreamWant{
 			Quantity:         8,
 			PreferIlm:        true,
 			DSManagedBy:      managedByILM,
 			IndicesPerDs:     1,
 			IndicesManagedBy: []string{managedByILM},
 		},
-		checkPostUpgradeAfterIngest: checkDatastreamWant{
+		checkPostUpgradeAfterIngest: checkDataStreamWant{
 			Quantity:         8,
 			PreferIlm:        true,
 			DSManagedBy:      managedByILM,
@@ -89,14 +89,14 @@ func runBasicUpgradeLazyRolloverDSLTest(
 	testCase := singleUpgradeTestCase{
 		fromVersion: fromVersion,
 		toVersion:   toVersion,
-		checkPreUpgradeAfterIngest: checkDatastreamWant{
+		checkPreUpgradeAfterIngest: checkDataStreamWant{
 			Quantity:         8,
 			PreferIlm:        false,
 			DSManagedBy:      managedByDSL,
 			IndicesPerDs:     1,
 			IndicesManagedBy: []string{managedByDSL},
 		},
-		checkPostUpgradeBeforeIngest: checkDatastreamWant{
+		checkPostUpgradeBeforeIngest: checkDataStreamWant{
 			Quantity:         8,
 			PreferIlm:        false,
 			DSManagedBy:      managedByDSL,
@@ -105,7 +105,7 @@ func runBasicUpgradeLazyRolloverDSLTest(
 		},
 		// Verify lazy rollover happened, i.e. 2 indices per data stream.
 		// Check data streams are managed by DSL.
-		checkPostUpgradeAfterIngest: checkDatastreamWant{
+		checkPostUpgradeAfterIngest: checkDataStreamWant{
 			Quantity:         8,
 			PreferIlm:        false,
 			DSManagedBy:      managedByDSL,

--- a/functionaltests/internal/esclient/client.go
+++ b/functionaltests/internal/esclient/client.go
@@ -139,24 +139,24 @@ func (c *Client) GetDataStream(ctx context.Context, name string) ([]types.DataSt
 	return resp.DataStreams, nil
 }
 
-// ApmDocCount is used to unmarshal response from ES|QL query in ApmDocCount().
-type ApmDocCount struct {
+// DocCount is used to unmarshal response from ES|QL query in APMDocCount().
+type DocCount struct {
 	Count      int
-	Datastream string
+	DataStream string
 }
 
-// APMDataStreamsDocCount is an easy to assert on format reporting doc count for
-// APM data streams.
-type APMDataStreamsDocCount map[string]int
+// DataStreamsDocCount is an easy to assert on format reporting document count
+// for data streams.
+type DataStreamsDocCount map[string]int
 
-func (c *Client) ApmDocCount(ctx context.Context) (APMDataStreamsDocCount, error) {
+func (c *Client) APMDocCount(ctx context.Context) (DataStreamsDocCount, error) {
 	q := `FROM traces-apm*,apm-*,traces-*.otel-*,logs-apm*,apm-*,logs-*.otel-*,metrics-apm*,apm-*,metrics-*.otel-*
 | EVAL datastream = CONCAT(data_stream.type, "-", data_stream.dataset, "-", data_stream.namespace)
 | STATS count = COUNT(*) BY datastream
 | SORT count DESC`
 
 	qry := c.es.Esql.Query().Query(q)
-	resp, err := query.Helper[ApmDocCount](ctx, qry)
+	resp, err := query.Helper[DocCount](ctx, qry)
 	if err != nil {
 		var eserr *types.ElasticsearchError
 		// suppress this error as it only indicates no data is available yet.
@@ -165,15 +165,15 @@ line 1:1: Unknown index [traces-apm*,apm-*,traces-*.otel-*,logs-apm*,apm-*,logs-
 		if errors.As(err, &eserr) &&
 			eserr.ErrorCause.Reason != nil &&
 			*eserr.ErrorCause.Reason == expected {
-			return APMDataStreamsDocCount{}, nil
+			return DataStreamsDocCount{}, nil
 		}
 
-		return APMDataStreamsDocCount{}, fmt.Errorf("cannot retrieve APM doc count: %w", err)
+		return DataStreamsDocCount{}, fmt.Errorf("cannot retrieve APM doc count: %w", err)
 	}
 
-	res := APMDataStreamsDocCount{}
+	res := DataStreamsDocCount{}
 	for _, dc := range resp {
-		res[dc.Datastream] = dc.Count
+		res[dc.DataStream] = dc.Count
 	}
 
 	return res, nil

--- a/functionaltests/single_upgrade_test.go
+++ b/functionaltests/single_upgrade_test.go
@@ -53,10 +53,10 @@ type singleUpgradeTestCase struct {
 
 	dataStreamNamespace          string
 	setupFn                      additionalFunc
-	checkPreUpgradeAfterIngest   checkDatastreamWant
+	checkPreUpgradeAfterIngest   checkDataStreamWant
 	postUpgradeFn                additionalFunc
-	checkPostUpgradeBeforeIngest checkDatastreamWant
-	checkPostUpgradeAfterIngest  checkDatastreamWant
+	checkPostUpgradeBeforeIngest checkDataStreamWant
+	checkPostUpgradeAfterIngest  checkDataStreamWant
 
 	apmErrorLogsIgnored []types.Query
 }
@@ -87,7 +87,7 @@ func (tt singleUpgradeTestCase) Run(t *testing.T) {
 	g := gen.New(esCfg.APMServerURL, apiKey)
 	g.Logger = zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
 
-	previous, err := getDocsCountPerDS(t, ctx, esc)
+	atStartCount, err := getDocsCountPerDS(t, ctx, esc)
 	require.NoError(t, err)
 
 	if tt.setupFn != nil {
@@ -102,16 +102,16 @@ func (tt singleUpgradeTestCase) Run(t *testing.T) {
 
 	t.Log("------ pre-upgrade ingestion assertions ------")
 	t.Log("check number of documents after initial ingestion")
-	atStartCount, err := getDocsCountPerDS(t, ctx, esc)
+	firstIngestCount, err := getDocsCountPerDS(t, ctx, esc)
 	require.NoError(t, err)
-	assertDocCount(t, atStartCount, previous,
+	assertDocCount(t, firstIngestCount, atStartCount,
 		expectedIngestForASingleRun(tt.dataStreamNamespace),
 		aggregationDataStreams(tt.dataStreamNamespace))
 
 	t.Log("check data streams after initial ingestion")
 	dss, err := esc.GetDataStream(ctx, "*apm*")
 	require.NoError(t, err)
-	assertDatastreams(t, tt.checkPreUpgradeAfterIngest, dss)
+	assertDataStreams(t, tt.checkPreUpgradeAfterIngest, dss)
 	t.Logf("time elapsed: %s", time.Since(start))
 
 	beforeUpgradeCount, err := getDocsCountPerDS(t, ctx, esc)
@@ -133,13 +133,16 @@ func (tt singleUpgradeTestCase) Run(t *testing.T) {
 	// and further assertions.
 	// We don't expect any change here unless something broke during the upgrade.
 	t.Log("check number of documents across upgrade")
-	assertDocCount(t, beforeUpgradeCount, esclient.APMDataStreamsDocCount{},
-		atStartCount, aggregationDataStreams(tt.dataStreamNamespace))
+	afterUpgradeCount, err := getDocsCountPerDS(t, ctx, esc)
+	require.NoError(t, err)
+	assertDocCount(t, afterUpgradeCount, beforeUpgradeCount,
+		emptyIngestForASingleRun(tt.dataStreamNamespace),
+		aggregationDataStreams(tt.dataStreamNamespace))
 
 	t.Log("check data streams after upgrade")
 	dss, err = esc.GetDataStream(ctx, "*apm*")
 	require.NoError(t, err)
-	assertDatastreams(t, tt.checkPostUpgradeBeforeIngest, dss)
+	assertDataStreams(t, tt.checkPostUpgradeBeforeIngest, dss)
 
 	t.Log("------ post-upgrade ingestion ------")
 	require.NoError(t, g.RunBlockingWait(ctx, kbc, tt.toVersion.String()))
@@ -147,15 +150,16 @@ func (tt singleUpgradeTestCase) Run(t *testing.T) {
 
 	t.Log("------ post-upgrade ingestion assertions ------")
 	t.Log("check number of documents after final ingestion")
-	afterUpgradeIngestionCount, err := getDocsCountPerDS(t, ctx, esc)
+	secondIngestCount, err := getDocsCountPerDS(t, ctx, esc)
 	require.NoError(t, err)
-	assertDocCount(t, afterUpgradeIngestionCount, beforeUpgradeCount,
-		expectedIngestForASingleRun(tt.dataStreamNamespace), aggregationDataStreams(tt.dataStreamNamespace))
+	assertDocCount(t, secondIngestCount, afterUpgradeCount,
+		expectedIngestForASingleRun(tt.dataStreamNamespace),
+		aggregationDataStreams(tt.dataStreamNamespace))
 
 	t.Log("check data streams after final ingestion")
 	dss2, err := esc.GetDataStream(ctx, "*apm*")
 	require.NoError(t, err)
-	assertDatastreams(t, tt.checkPostUpgradeAfterIngest, dss2)
+	assertDataStreams(t, tt.checkPostUpgradeAfterIngest, dss2)
 	t.Logf("time elapsed: %s", time.Since(start))
 
 	t.Log("------ check ES and APM error logs ------")


### PR DESCRIPTION
## Motivation/summary

Fix post-upgrade document count assertion, previously it was checking before-ingestion count vs before-upgrade count, it should be before-upgrade vs after-upgrade.

Also makes the following rename changes:
- `Datastream` -> `DataStream` for consistency
- `ApmDocCount` -> `DocCount` and `APMDataStreamsDocCount` -> `DataStreamsDocCount` since there's nothing APM related in there
- `ApmDocCount()` -> `APMDocCount` for consistency

## How to test these changes

Run functionaltests with this branch: https://github.com/elastic/apm-server/actions/runs/14060343893.