### PR TITLE
functionaltests: Add support for interacting with v7 fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
       - run: go test -v -race ./...
       - env:
           KIBANA_URL: "https://kibana.test"
-          KIBANA_API_KEY: "dummy"
+          KIBANA_USERNAME: "dummy"
+          KIBANA_PASSWORD: "dummy"
           EC_URL: "https://elastic-cloud.test"
           EC_API_KEY: "dummy"
           EC_REGION: "gcp-us-west2"

--- a/functionaltests/internal/gen/generator.go
+++ b/functionaltests/internal/gen/generator.go
@@ -135,7 +135,7 @@ func (g *Generator) RunBlockingWait(ctx context.Context, version ecclient.StackV
 	}
 
 	// With standalone, we don't have Fleet, so simply just wait for some arbitrary time.
-	time.Sleep(30 * time.Second)
+	time.Sleep(60 * time.Second)
 	return nil
 }
 
@@ -158,17 +158,14 @@ func flushAPMMetrics(ctx context.Context, kbc *kbclient.Client, version string) 
 	// Sending an update with modifying the description is enough to trigger
 	// final aggregations in APM Server and flush of in-flight metrics.
 	policy.Description = fmt.Sprintf("Functional tests %s", version)
-	if err = kbc.UpdatePackagePolicyByID(ctx, policyID, kbclient.UpdatePackagePolicyRequest{
-		PackagePolicy: policy,
-		Force:         false,
-	}); err != nil {
+	if err = kbc.UpdatePackagePolicyByID(ctx, policyID, policy); err != nil {
 		return fmt.Errorf("cannot update elastic-cloud-apm package policy: %w", err)
 	}
 
 	// APM Server needs some time to flush all metrics, and we don't have any
 	// visibility on when this completes.
 	// NOTE: This value comes from empirical observations.
-	time.Sleep(20 * time.Second)
+	time.Sleep(40 * time.Second)
 	return nil
 }
 

--- a/functionaltests/internal/kbclient/client_test.go
+++ b/functionaltests/internal/kbclient/client_test.go
@@ -110,8 +110,9 @@ func getHttpClient(t *testing.T) (*recorder.Recorder, *http.Client) {
 
 func TestClient_GetPackagePolicyByID(t *testing.T) {
 	kibanaURL := os.Getenv("KIBANA_URL")
-	apikey := os.Getenv("KIBANA_API_KEY")
-	kbc, err := kbclient.New(kibanaURL, apikey, "", "")
+	username := os.Getenv("KIBANA_USERNAME")
+	password := os.Getenv("KIBANA_PASSWORD")
+	kbc, err := kbclient.New(kibanaURL, username, password)
 	require.NoError(t, err)
 	_, httpc := getHttpClient(t)
 	kbc.Client = *httpc
@@ -123,16 +124,17 @@ func TestClient_GetPackagePolicyByID(t *testing.T) {
 
 func TestClient_UpdatePackagePolicyByID(t *testing.T) {
 	kibanaURL := os.Getenv("KIBANA_URL")
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	kbc, err := kbclient.New(kibanaURL, apiKey, "", "")
+	username := os.Getenv("KIBANA_USERNAME")
+	password := os.Getenv("KIBANA_PASSWORD")
+	kbc, err := kbclient.New(kibanaURL, username, password)
 	require.NoError(t, err)
 	_, httpc := getHttpClient(t)
 	kbc.Client = *httpc
 
 	ctx := context.Background()
 	policyID := "elastic-cloud-apm"
-	err = kbc.UpdatePackagePolicyByID(ctx, policyID, kbclient.UpdatePackagePolicyRequest{
-		PackagePolicy: kbclient.PackagePolicy{
+	err = kbc.UpdatePackagePolicyByID(ctx, policyID,
+		kbclient.PackagePolicy{
 			Name:        "Elastic APM",
 			Description: "Hello World",
 			Package: kbclient.PackagePolicyPkg{
@@ -140,8 +142,7 @@ func TestClient_UpdatePackagePolicyByID(t *testing.T) {
 				Version: "9.1.0-SNAPSHOT",
 			},
 		},
-		Force: false,
-	})
+	)
 	require.NoError(t, err)
 
 	policy, err := kbc.GetPackagePolicyByID(ctx, policyID)

--- a/functionaltests/single_upgrade_test.go
+++ b/functionaltests/single_upgrade_test.go
@@ -80,7 +80,7 @@ func (tt singleUpgradeTestCase) Run(t *testing.T) {
 	t.Logf("time elapsed: %s", time.Since(start))
 
 	esc := createESClient(t, deployInfo)
-	kbc := createKibanaClient(t, ctx, esc, deployInfo)
+	kbc := createKibanaClient(t, deployInfo)
 	g := createAPMGenerator(t, ctx, esc, kbc, deployInfo)
 
 	atStartCount := getDocCountPerDS(t, ctx, esc)

--- a/functionaltests/steps_test.go
+++ b/functionaltests/steps_test.go
@@ -129,7 +129,7 @@ func (c createStep) Step(t *testing.T, ctx context.Context, e *testStepEnv, _ te
 	integrations := c.APMDeploymentMode.enableIntegrations()
 	deployInfo := createCluster(t, ctx, e.tf, *target, c.DeployVersion, integrations)
 	e.esc = createESClient(t, deployInfo)
-	e.kbc = createKibanaClient(t, ctx, e.esc, deployInfo)
+	e.kbc = createKibanaClient(t, deployInfo)
 	e.gen = createAPMGenerator(t, ctx, e.esc, e.kbc, deployInfo)
 	// Update the environment version to the new one.
 	e.version = c.DeployVersion

--- a/functionaltests/utils_test.go
+++ b/functionaltests/utils_test.go
@@ -170,12 +170,10 @@ func createESClient(t *testing.T, deployInfo deploymentInfo) *esclient.Client {
 
 // createKibanaClient instantiate an HTTP API client with dedicated methods to query the Kibana API.
 // This function will also create an Elasticsearch API key with full permissions to be used by the HTTP client.
-func createKibanaClient(t *testing.T, ctx context.Context, esc *esclient.Client, deployInfo deploymentInfo) *kbclient.Client {
+func createKibanaClient(t *testing.T, deployInfo deploymentInfo) *kbclient.Client {
 	t.Helper()
 	t.Log("create kibana client")
-	apiKey, err := esc.CreateAPIKey(ctx, "kbclient", -1, map[string]types.RoleDescriptor{})
-	require.NoError(t, err)
-	kbc, err := kbclient.New(deployInfo.KibanaURL, apiKey, deployInfo.Username, deployInfo.Password)
+	kbc, err := kbclient.New(deployInfo.KibanaURL, deployInfo.Username, deployInfo.Password)
 	require.NoError(t, err)
 	return kbc
 }


### PR DESCRIPTION
## Motivation/summary

We are planning to add a test for 7.x standalone -> 7.x managed -> 8.x managed. However, the 7.x Fleet API, that we use to trigger flushing of APM metrics, is only accessible to superuser.

- Add new fields to `PackagePolicy` that are necessary for update in 7.x
- Remove API key from `kbclient.Client`, since we are only using superuser basic auth
- Increase waiting time after ingestion (aggregation metrics occasionally take longer than expected to arrive in ES)

## How to test these changes

Run functionaltests with this branch.

I have also tested locally that versions from 8.15 to 9.1 are not affected negatively by this change, i.e. the `UpdatePackagePolicyByID` function works as per normal (no changes to unexpected policy fields).
