### PR TITLE
test(TestMonitoring): swap assertion args to fix flaky test

### DIFF
--- a/systemtest/monitoring_test.go
+++ b/systemtest/monitoring_test.go
@@ -72,7 +72,7 @@ func TestMonitoring(t *testing.T) {
 		Output  json.RawMessage
 	}
 
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		metrics.Libbeat = nil
 		metrics.Output = nil
 		getBeatsMonitoringStats(t, srv, &metrics)
@@ -95,8 +95,8 @@ func TestMonitoring(t *testing.T) {
 	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.active").Int())
 	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.failed").Int())
 	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.toomany").Int())
-	assert.GreaterOrEqual(t, int64(N), gjson.GetBytes(metrics.Libbeat, "output.events.total").Int())
-	assert.GreaterOrEqual(t, int64(N), gjson.GetBytes(metrics.Libbeat, "pipeline.events.total").Int())
+	assert.GreaterOrEqual(t, gjson.GetBytes(metrics.Libbeat, "output.events.total").Int(), int64(N))
+	assert.GreaterOrEqual(t, gjson.GetBytes(metrics.Libbeat, "pipeline.events.total").Int(), int64(N))
 	assert.Equal(t, "elasticsearch", gjson.GetBytes(metrics.Libbeat, "output.type").Str)
 
 	bulkRequestsAvailable := gjson.GetBytes(metrics.Output, "elasticsearch.bulk_requests.available")


### PR DESCRIPTION
## Motivation/summary

the assertion was checking N >= total which only happens if N==total

the intended check was to pass if total >= N (expected).

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/16517
