### PR TITLE
functionaltests: Add test for 7x to 8x to 9x

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -35,6 +35,7 @@ jobs:
           - '8.x' # Latest 8 version
           - '9.0'
           - '9.1'
+          - '9.x' # Latest 9 version
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -60,7 +61,7 @@ jobs:
           export TF_VAR_CREATED_DATE=$(date +%s)
           VERSION="${{ matrix.active-version }}"
           VERSION="${VERSION//./_}"
-          go test -run="_to_${VERSION}" -skip="_to_${VERSION}_to_" -v -timeout=40m -target="${{ matrix.environment }}" ./
+          go test -run="_to_${VERSION}" -skip="_to_${VERSION}_to_" -v -timeout=60m -target="${{ matrix.environment }}" ./
 
 #  notify:
 #    if: always()

--- a/functionaltests/9_x_test.go
+++ b/functionaltests/9_x_test.go
@@ -1,0 +1,193 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package functionaltests
+
+import (
+	"testing"
+
+	"github.com/elastic/apm-server/functionaltests/internal/asserts"
+	"github.com/elastic/apm-server/functionaltests/internal/ecclient"
+)
+
+func TestUpgrade_7_17_to_8_x_to_9_x__Snapshot_Standalone_to_Managed(t *testing.T) {
+	fromVersion7 := getLatestSnapshot(t, "7.17")
+	toVersion8 := getLatestSnapshot(t, "8")
+	toVersion9 := getLatestSnapshot(t, "9")
+
+	t.Run("UpgradeFirst", func(t *testing.T) {
+		t.Parallel()
+		runner := upgradeThenManaged789Runner(fromVersion7, toVersion8, toVersion9)
+		runner.Run(t)
+	})
+
+	t.Run("ManagedFirst", func(t *testing.T) {
+		t.Parallel()
+		runner := managedThenUpgrade789Runner(fromVersion7, toVersion8, toVersion9)
+		runner.Run(t)
+	})
+}
+
+func TestUpgrade_7_17_to_8_x_to_9_x__BC_Standalone_to_Managed(t *testing.T) {
+	fromVersion7 := getLatestVersionOrSkip(t, "7.17")
+	toVersion8 := getLatestVersionOrSkip(t, "8")
+	toVersion9 := getLatestBCOrSkip(t, "9")
+
+	t.Run("UpgradeFirst", func(t *testing.T) {
+		t.Parallel()
+		runner := upgradeThenManaged789Runner(fromVersion7, toVersion8, toVersion9)
+		runner.Run(t)
+	})
+
+	t.Run("ManagedFirst", func(t *testing.T) {
+		t.Parallel()
+		runner := managedThenUpgrade789Runner(fromVersion7, toVersion8, toVersion9)
+		runner.Run(t)
+	})
+}
+
+func upgradeThenManaged789Runner(fromVersion7, toVersion8, toVersion9 ecclient.StackVersion) testStepsRunner {
+	// Data streams in 8.x should be all ILM if upgraded to a stack < 8.15 and > 8.16.
+	checkILM := asserts.CheckDataStreamsWant{
+		Quantity:         8,
+		PreferIlm:        true,
+		DSManagedBy:      managedByILM,
+		IndicesPerDS:     1,
+		IndicesManagedBy: []string{managedByILM},
+	}
+
+	return testStepsRunner{
+		Steps: []testStep{
+			// Start from 7.x.
+			createStep{
+				DeployVersion:     fromVersion7,
+				APMDeploymentMode: apmStandalone,
+			},
+			ingestV7Step{},
+			// Upgrade to 8.x.
+			upgradeV7Step{NewVersion: toVersion8},
+			ingestStep{CheckDataStream: checkILM},
+			// Resolve deprecations and upgrade to 9.x.
+			resolveDeprecationsStep{},
+			upgradeStep{
+				NewVersion:      toVersion9,
+				CheckDataStream: checkILM,
+			},
+			ingestStep{CheckDataStream: checkILM},
+			// Migrate to managed.
+			migrateManagedStep{},
+			ingestStep{CheckDataStream: checkILM},
+			checkErrorLogsStep{
+				ESErrorLogsIgnored: esErrorLogs{
+					eventLoopShutdown,
+				},
+				APMErrorLogsIgnored: apmErrorLogs{
+					tlsHandshakeError,
+					esReturnedUnknown503,
+					refreshCache503,
+					populateSourcemapFetcher403,
+					refreshCache403,
+					refreshCacheESConfigInvalid,
+				},
+			},
+		},
+	}
+}
+
+func managedThenUpgrade789Runner(fromVersion7, toVersion8, toVersion9 ecclient.StackVersion) testStepsRunner {
+	checkILM := asserts.CheckDataStreamIndividualWant{
+		PreferIlm:        true,
+		DSManagedBy:      managedByILM,
+		IndicesManagedBy: []string{managedByILM},
+	}
+	checkILMRollover := asserts.CheckDataStreamIndividualWant{
+		PreferIlm:        true,
+		DSManagedBy:      managedByILM,
+		IndicesManagedBy: []string{managedByILM, managedByILM},
+	}
+
+	check := map[string]asserts.CheckDataStreamIndividualWant{
+		// These data streams are created in 7.x as well, so when we ingest
+		// again in 8.x, they will be rolled-over.
+		"traces-apm-%s":                     checkILMRollover,
+		"metrics-apm.app.opbeans_python-%s": checkILMRollover,
+		"metrics-apm.internal-%s":           checkILMRollover,
+		"logs-apm.error-%s":                 checkILMRollover,
+		// These data streams are only created in 8.x, so they will only have
+		// 1 index.
+		"metrics-apm.service_destination.1m-%s": checkILM,
+		"metrics-apm.service_transaction.1m-%s": checkILM,
+		"metrics-apm.service_summary.1m-%s":     checkILM,
+		"metrics-apm.transaction.1m-%s":         checkILM,
+	}
+
+	// These data streams are created in 7.x, but not used in 8.x and 9.x,
+	// so we ignore them to avoid wrong assertions.
+	ignoredDataStreams := []string{
+		"metrics-apm.app.opbeans_node-%s",
+		"metrics-apm.app.opbeans_ruby-%s",
+		"metrics-apm.app.opbeans_go-%s",
+	}
+
+	return testStepsRunner{
+		Steps: []testStep{
+			// Start from 7.x.
+			createStep{
+				DeployVersion:     fromVersion7,
+				APMDeploymentMode: apmStandalone,
+			},
+			ingestV7Step{},
+			// Migrate to managed.
+			migrateManagedStep{},
+			ingestV7Step{},
+			// Upgrade to 8.x.
+			upgradeV7Step{NewVersion: toVersion8},
+			ingestStep{
+				IgnoreDataStreams:         ignoredDataStreams,
+				CheckIndividualDataStream: check,
+			},
+			// Resolve deprecations and upgrade to 9.x.
+			resolveDeprecationsStep{},
+			upgradeStep{
+				NewVersion:                toVersion9,
+				IgnoreDataStreams:         ignoredDataStreams,
+				CheckIndividualDataStream: check,
+			},
+			ingestStep{
+				IgnoreDataStreams:         ignoredDataStreams,
+				CheckIndividualDataStream: check,
+			},
+			checkErrorLogsStep{
+				ESErrorLogsIgnored: esErrorLogs{
+					eventLoopShutdown,
+					addIndexTemplateTracesError,
+				},
+				APMErrorLogsIgnored: apmErrorLogs{
+					tlsHandshakeError,
+					esReturnedUnknown503,
+					refreshCache503,
+					preconditionClusterInfoCtxCanceled,
+					waitServerReadyCtxCanceled,
+					grpcServerStopped,
+					populateSourcemapFetcher403,
+					refreshCache403,
+					refreshCacheESConfigInvalid,
+				},
+			},
+		},
+	}
+}

--- a/functionaltests/internal/gen/generator.go
+++ b/functionaltests/internal/gen/generator.go
@@ -105,7 +105,7 @@ func (g *Generator) runBlocking(ctx context.Context, version ecclient.StackVersi
 	}
 
 	g.logger.Info("wait for apm server to be ready")
-	if err = g.waitForAPMToBePublishReady(ctx, 20*time.Second); err != nil {
+	if err = g.waitForAPMToBePublishReady(ctx, 30*time.Second); err != nil {
 		return err
 	}
 

--- a/functionaltests/internal/kbclient/client.go
+++ b/functionaltests/internal/kbclient/client.go
@@ -77,6 +77,7 @@ func (c *Client) prepareRequest(method, path string, body any) (*http.Request, e
 	req.Header.Add("kbn-xsrf", "true")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Elastic-Api-Version", c.SupportedAPIVersion)
+	req.Header.Add("X-Elastic-Internal-Origin", "Kibana")
 
 	userPass := fmt.Sprintf("%s:%s", c.superUsername, c.superPassword)
 	basicAuth := base64.StdEncoding.EncodeToString([]byte(userPass))

--- a/functionaltests/main_test.go
+++ b/functionaltests/main_test.go
@@ -135,6 +135,19 @@ func getLatestBCOrSkip(t *testing.T, prefix string) ecclient.StackVersion {
 		t.Skipf("BC for '%s' not found in EC region %s, skipping test", prefix, regionFrom(*target))
 		return ecclient.StackVersion{}
 	}
+
+	// Check that the BC version is actually latest, otherwise skip test.
+	version := getLatestVersionOrSkip(t, prefix)
+	if version.Major != candidate.Major {
+		t.Skipf("BC for '%s' is invalid in EC region %s, skipping test", prefix, regionFrom(*target))
+		return ecclient.StackVersion{}
+	}
+	if version.Minor > candidate.Minor {
+		t.Skipf("BC for '%s' is less than latest normal version in EC region %s, skipping test",
+			prefix, regionFrom(*target))
+		return ecclient.StackVersion{}
+	}
+
 	return candidate
 }
 

--- a/functionaltests/steps_test.go
+++ b/functionaltests/steps_test.go
@@ -188,11 +188,11 @@ func (i ingestStep) Step(t *testing.T, ctx context.Context, e *testStepEnv, prev
 		t.Fatal("ingest step should only be used for versions >= 8.0")
 	}
 
-	t.Log("------ ingest ------")
+	t.Logf("------ ingest in %s------", e.currentVersion())
 	err := e.gen.RunBlockingWait(ctx, e.currentVersion(), e.integrations)
 	require.NoError(t, err)
 
-	t.Log("------ ingest check ------")
+	t.Logf("------ ingest check in %s ------", e.currentVersion())
 	t.Log("check number of documents after ingestion")
 	ignoreDS := formatAll(i.IgnoreDataStreams, e.dsNamespace)
 	dsDocCount := getDocCountPerDS(t, ctx, e.esc, ignoreDS...)
@@ -237,6 +237,13 @@ func formatAllMap[T any](m map[string]T, s string) map[string]T {
 type upgradeStep struct {
 	NewVersion      ecclient.StackVersion
 	CheckDataStream asserts.CheckDataStreamsWant
+	// IgnoreDataStreams are the data streams to be ignored in assertions.
+	// The data stream names can contain '%s' to indicate namespace.
+	IgnoreDataStreams []string
+	// CheckIndividualDataStream is used to check the data streams individually
+	// instead of as a whole using CheckDataStream.
+	// The data stream names can contain '%s' to indicate namespace.
+	CheckIndividualDataStream map[string]asserts.CheckDataStreamIndividualWant
 }
 
 var _ testStep = upgradeStep{}
@@ -251,18 +258,24 @@ func (u upgradeStep) Step(t *testing.T, ctx context.Context, e *testStepEnv, pre
 	// Update the environment version to the new one.
 	e.versions = append(e.versions, u.NewVersion)
 
-	t.Log("------ upgrade check ------")
+	t.Logf("------ upgrade check in %s ------", e.currentVersion())
 	t.Log("check number of documents across upgrade")
 	// We assert that no changes happened in the number of documents after upgrade
 	// to ensure the state didn't change.
 	// We don't expect any change here unless something broke during the upgrade.
-	dsDocCount := getDocCountPerDS(t, ctx, e.esc)
+	ignoreDS := formatAll(u.IgnoreDataStreams, e.dsNamespace)
+	dsDocCount := getDocCountPerDS(t, ctx, e.esc, ignoreDS...)
 	asserts.CheckDocCount(t, dsDocCount, previousRes.DSDocCount,
 		emptyDataStreamsIngest(e.dsNamespace))
 
 	t.Log("check data streams after upgrade")
-	dataStreams := getAPMDataStreams(t, ctx, e.esc)
-	asserts.CheckDataStreams(t, u.CheckDataStream, dataStreams)
+	dataStreams := getAPMDataStreams(t, ctx, e.esc, ignoreDS...)
+	if u.CheckIndividualDataStream != nil {
+		expected := formatAllMap(u.CheckIndividualDataStream, e.dsNamespace)
+		asserts.CheckDataStreamsIndividually(t, expected, dataStreams)
+	} else {
+		asserts.CheckDataStreams(t, u.CheckDataStream, dataStreams)
+	}
 
 	return testStepResult{DSDocCount: dsDocCount}
 }

--- a/functionaltests/steps_v7_test.go
+++ b/functionaltests/steps_v7_test.go
@@ -203,6 +203,10 @@ func (m migrateManagedStep) Step(t *testing.T, ctx context.Context, e *testStepE
 	return testStepResult{DSDocCount: dsDocCount}
 }
 
+// resolveDeprecationsStep resolves critical migration deprecation warnings from Elasticsearch regarding
+// indices created in 7.x not being compatible with 9.x.
+//
+// The output of this step is the previous test step result.
 type resolveDeprecationsStep struct{}
 
 var _ testStep = resolveDeprecationsStep{}

--- a/functionaltests/steps_v7_test.go
+++ b/functionaltests/steps_v7_test.go
@@ -94,11 +94,11 @@ func (i ingestV7Step) Step(t *testing.T, ctx context.Context, e *testStepEnv, pr
 		t.Fatal("ingest v7 step should only be used for versions < 8.0")
 	}
 
-	t.Log("------ ingest ------")
+	t.Logf("------ ingest in %s ------", e.currentVersion())
 	err := e.gen.RunBlockingWait(ctx, e.currentVersion(), e.integrations)
 	require.NoError(t, err)
 
-	t.Log("------ ingest check ------")
+	t.Logf("------ ingest check in %s ------", e.currentVersion())
 	t.Log("check number of documents after ingestion")
 	// Standalone, check indices.
 	if !e.integrations {
@@ -139,7 +139,7 @@ func (u upgradeV7Step) Step(t *testing.T, ctx context.Context, e *testStepEnv, p
 	// Update the environment version to the new one.
 	e.versions = append(e.versions, u.NewVersion)
 
-	t.Log("------ upgrade check ------")
+	t.Logf("------ upgrade check in %s ------", e.currentVersion())
 	t.Log("check number of documents across upgrade")
 	// We assert that no changes happened in the number of documents after upgrade
 	// to ensure the state didn't change.
@@ -175,7 +175,7 @@ func (m migrateManagedStep) Step(t *testing.T, ctx context.Context, e *testStepE
 		t.Fatal("migrate managed step should only be used on standalone")
 	}
 
-	t.Log("------ migrate to managed ------")
+	t.Logf("------ migrate to managed for %s ------", e.currentVersion())
 	t.Log("enable integrations server")
 	err := e.kbc.EnableIntegrationsServer(ctx)
 	require.NoError(t, err)
@@ -201,4 +201,15 @@ func (m migrateManagedStep) Step(t *testing.T, ctx context.Context, e *testStepE
 	asserts.CheckDocCount(t, dsDocCount, previousRes.DSDocCount,
 		emptyDataStreamsIngest(e.dsNamespace))
 	return testStepResult{DSDocCount: dsDocCount}
+}
+
+type resolveDeprecationsStep struct{}
+
+var _ testStep = resolveDeprecationsStep{}
+
+func (r resolveDeprecationsStep) Step(t *testing.T, ctx context.Context, e *testStepEnv, previousRes testStepResult) testStepResult {
+	t.Logf("------ resolve migration deprecations in %s ------", e.currentVersion())
+	err := e.kbc.ResolveMigrationDeprecations(ctx)
+	require.NoError(t, err)
+	return previousRes
 }


### PR DESCRIPTION
## Motivation/summary

Add 7.x to 8.x to 9.x test, for standalone to managed.
- 7.x standalone -> 8.x standalone -> 9.x standalone -> 9.x managed
- 7.x standalone -> 7.x managed -> 8.x managed -> 9.x managed

Closes https://github.com/elastic/apm-server/issues/16199. Requires all other functionaltests PR to be merged first.

## How to test these changes

Run functionaltest workflow with this branch: https://github.com/elastic/apm-server/actions/runs/14465245943.