### PR TITLE
New way of backporting to active branches using gh action

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -1,0 +1,22 @@
+name: Backport to active branches
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  backport:
+    # Only run if the PR was merged (not just closed) and has one of the backport labels
+    if: |
+      github.event.pull_request.merged == true && 
+      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: elastic/oblt-actions/github/backport-active@v1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+commands_restrictions:
+  backport:
+    conditions:
+      - or:
+        - sender-permission>=write
+        - sender=github-actions[bot]
 queue_rules:
   - name: default
     merge_method: squash
@@ -7,6 +13,14 @@ queue_rules:
       - check-success=system-test
       - check-success=lint
       - check-success=CLA
+defaults:
+  actions:
+    backport:
+      title: "[{{ destination_branch }}] (backport #{{ number }}) {{ title }}"
+      assignees:
+        - "{{ author }}"
+      labels:
+        - "backport"
 pull_request_rules:
   - name: ask to resolve conflict
     conditions:
@@ -436,58 +450,3 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-
-  - name: backport patches to all active minor branches for the 8 major.
-    conditions:
-      - merged
-      - base=main
-      - label=backport-active-8
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing minor branch reached EOL.
-        branches:
-          - "8.x"
-          - "8.18"
-          - "8.17"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to all active minor branches for the 9 major.
-    conditions:
-      - merged
-      - base=main
-      - label=backport-active-9
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing minor branch reached EOL.
-        branches:
-          - "9.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to all active branches
-    conditions:
-      - merged
-      - base=main
-      - label=backport-active-all
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing release branch reached EOL.
-        branches:
-          - "9.0"
-          - "8.18"
-          - "8.17"
-          - "8.x"
-          - "7.17"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Adding new gh action for backporting to active branches using new gh action.
<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

