### PR TITLE
mergify: support 8.19 and remove support 8.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -189,7 +189,6 @@ pull_request_rules:
           * `backport-7.17` is the label to automatically backport to the 7.17 branch.
           * `backport-8./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit.
           * `backport-9./d` is the label to automatically backport to the `9./d` branch. `/d` is the digit.
-          * `backport-8.x` is the label to automatically backport to the `8.x` branch.
           * `backport-active-all` is the label that automatically backports to all active branches.
           * `backport-active-8` is the label that automatically backports to all active minor branches for the 8 major.
           * `backport-active-9` is the label that automatically backports to all active minor branches for the 9 major.
@@ -200,13 +199,6 @@ pull_request_rules:
       label:
         remove:
           - backport-skip
-  - name: remove backport-8.x label if backport-skip is present
-    conditions:
-      - label~=^backport-skip
-    actions:
-      label:
-        remove:
-          - backport-8.x
   - name: notify the backport has not been merged yet
     conditions:
       - -merged
@@ -380,20 +372,6 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-  - name: backport patches to 8.x branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-8.x
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.x"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
   - name: backport patches to 8.16 branch
     conditions:
       - merged
@@ -436,6 +414,15 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+  - name: backport patches to 8.19 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.19
+    actions:
+      backport:
+        branches:
+          - "8.19"
   - name: backport patches to 9.0 branch
     conditions:
       - merged

--- a/release.mk
+++ b/release.mk
@@ -252,13 +252,8 @@ update-mergify:
 		echo '      - label=backport-$(VERSION)'                                                >> .mergify.yml; \
 		echo '    actions:'                                                                     >> .mergify.yml; \
 		echo '      backport:'                                                                  >> .mergify.yml; \
-		echo '        assignees:'                                                               >> .mergify.yml; \
-		echo '          - "{{ author }}"'                                                       >> .mergify.yml; \
 		echo '        branches:'                                                                >> .mergify.yml; \
 		echo '          - "$(VERSION)"'                                                         >> .mergify.yml; \
-		echo '        labels:'                                                                  >> .mergify.yml; \
-		echo '          - "backport"'                                                           >> .mergify.yml; \
-		echo '        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"' >> .mergify.yml; \
 	else \
 		echo "::warn::Mergify already contains backport-$(VERSION)"; \
 	fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

`8.x` has been renamed to `8.19`

Use default values for the backport actions/rules.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
