### PR TITLE
TBS: ignore subscriber position read error and proceed as if file not exist

### DIFF
--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -7,7 +7,6 @@ package sampling
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -297,10 +296,7 @@ func (p *Processor) Run() error {
 		bulkIndexerFlushInterval = p.config.FlushInterval
 	}
 
-	initialSubscriberPosition, err := readSubscriberPosition(p.logger, p.config.DB)
-	if err != nil {
-		return err
-	}
+	initialSubscriberPosition := readSubscriberPosition(p.logger, p.config.DB)
 	subscriberPositions := make(chan pubsub.SubscriberPosition)
 	pubsub, err := pubsub.New(pubsub.Config{
 		ServerID:   p.config.UUID,
@@ -502,20 +498,22 @@ func (p *Processor) Run() error {
 	return nil
 }
 
-func readSubscriberPosition(logger *logp.Logger, s *eventstorage.StorageManager) (pubsub.SubscriberPosition, error) {
+func readSubscriberPosition(logger *logp.Logger, s *eventstorage.StorageManager) pubsub.SubscriberPosition {
 	var pos pubsub.SubscriberPosition
 	data, err := s.ReadSubscriberPosition()
 	if errors.Is(err, os.ErrNotExist) {
-		return pos, nil
+		return pos
 	} else if err != nil {
-		return pos, fmt.Errorf("error reading subscriber position file: %w", err)
+		logger.With(logp.Error(err)).Warn("error reading subscriber position file; proceeding with empty subscriber position")
+		return pos
 	}
 	err = json.Unmarshal(data, &pos)
 	if err != nil {
 		logger.With(logp.Error(err)).With(logp.ByteString("file", data)).Debug("failed to read subscriber position")
-		return pos, fmt.Errorf("error parsing subscriber position file: %w", err)
+		logger.With(logp.Error(err)).Warn("error parsing subscriber position file; proceeding with empty subscriber position")
+		return pos
 	}
-	return pos, nil
+	return pos
 }
 
 func writeSubscriberPosition(s *eventstorage.StorageManager, pos pubsub.SubscriberPosition) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Tail-based sampling: ignore subscriber position file and proceed as if file does not exist, to avoid apm-server getting stuck in crashloop in case of a corrupted subscriber position file

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc) **need individual changelogs for backported versions**
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

Run apm-server with invalid subscriber position file, or any file system read error (e.g. perms). Ensure that apm-server doesn't stop immediately.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #14760
