### PR TITLE
ci: disable go cache in other jobs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -93,6 +93,7 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - uses: rlespinasse/github-slug-action@955b5ba4560860f8a633bd24190941f16016e42c # 955b5ba4560860f8a633bd24190941f16016e42c
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version-file: 'functionaltests/go.mod'
+          cache: false
 
       - uses: elastic/oblt-actions/google/auth@db0844c27572a45966ce669e4d3073c205c8d5e4 # v1
 

--- a/.github/workflows/setup-cluster-env/action.yml
+++ b/.github/workflows/setup-cluster-env/action.yml
@@ -9,6 +9,4 @@ runs:
     - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
       with:
         go-version-file: go.mod
-        cache: true
-        cache-dependency-path: |
-          go.sum
+        cache: false

--- a/.github/workflows/update-beats.yml
+++ b/.github/workflows/update-beats.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version-file: go.mod
+          cache: false
 
       - uses: elastic/oblt-actions/updatecli/run@db0844c27572a45966ce669e4d3073c205c8d5e4 # v1
         with:

--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version-file: go.mod
+          cache: false
       - name: Update NOTICE.txt
         run: make notice
       - name: Debug diff


### PR DESCRIPTION
## Motivation/summary

prevent messing with the cache artifacts

some huge artifacts are still being created, they are probably from beats and docker compose bump workflows.

disable go cache to let the unit test jobs do the caching.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Related to https://github.com/elastic/apm-server/issues/16604
