### PR TITLE
fix: properly initiate logger

### DIFF
--- a/internal/publish/pub_test.go
+++ b/internal/publish/pub_test.go
@@ -140,18 +140,34 @@ func BenchmarkPublisher(b *testing.B) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	supporter, err := idxmgmt.DefaultSupport(beat.Info{}, nil)
+	supporter, err := idxmgmt.DefaultSupport(
+		beat.Info{
+			Logger: logptest.NewTestingLogger(b, "support"),
+		},
+		nil,
+	)
 	require.NoError(b, err)
-	outputGroup, err := outputs.Load(supporter, beat.Info{}, nil, "elasticsearch", config.MustNewConfigFrom(map[string]interface{}{
-		"hosts": []interface{}{srv.URL},
-	}))
+
+	outputGroup, err := outputs.Load(
+		supporter,
+		beat.Info{
+			Logger: logptest.NewTestingLogger(b, "output"),
+		},
+		nil,
+		"elasticsearch",
+		config.MustNewConfigFrom(map[string]interface{}{
+			"hosts": []interface{}{srv.URL},
+		}),
+	)
 	require.NoError(b, err)
+
 	conf, err := config.NewConfigFrom(map[string]interface{}{
 		"mem.events":           4096,
 		"mem.flush.min_events": 2048,
 		"mem.flush.timeout":    "1s",
 	})
 	require.NoError(b, err)
+
 	namespace := config.Namespace{}
 	err = conf.Unpack(&namespace)
 	require.NoError(b, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Fix panic when benchmarking

```
[2025-05-08T12:21:20Z] panic: runtime error: invalid memory address or nil pointer dereference
[2025-05-08T12:21:20Z] [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xeb3d57]
[2025-05-08T12:21:20Z] 
[2025-05-08T12:21:20Z] goroutine 50 [running]:
[2025-05-08T12:21:20Z] github.com/elastic/elastic-agent-libs/logp.(*Logger).Named(0xc0001799c0?, {0x192d7d0?, 0x251f680?})
[2025-05-08T12:21:20Z] 	/var/lib/buildkite-agent/go/pkg/mod/github.com/elastic/elastic-agent-libs@v0.19.4/logp/logger.go:150 +0x17
[2025-05-08T12:21:20Z] github.com/elastic/beats/v7/libbeat/idxmgmt.DefaultSupport.MakeDefaultSupport.func1(...)
[2025-05-08T12:21:20Z] 	/var/lib/buildkite-agent/go/pkg/mod/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20250505142450-af0a5dad0d45/libbeat/idxmgmt/idxmgmt.go:109
[2025-05-08T12:21:20Z] github.com/elastic/beats/v7/libbeat/idxmgmt.DefaultSupport({{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, 0x0, {0x0, 0x0}, {0x0, ...}, ...}, ...)
[2025-05-08T12:21:20Z] 	/var/lib/buildkite-agent/go/pkg/mod/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20250505142450-af0a5dad0d45/libbeat/idxmgmt/idxmgmt.go:97 +0x65
[2025-05-08T12:21:20Z] github.com/elastic/apm-server/internal/publish_test.BenchmarkPublisher(0xc0001682c8)
[2025-05-08T12:21:20Z] 	/var/lib/buildkite-agent/.buildkite-agent/builds/worker-1799330-build-hel1-dc1-hetzner-elasticnet-co/elastic/apm-agent-microbenchmark/apm-server-4e83d2cbd08ddc195f485b48aa8862d774a12fa5/internal/publish/pub_test.go:143 +0x15a
[2025-05-08T12:21:20Z] testing.(*B).runN(0xc0001682c8, 0x1)
[2025-05-08T12:21:20Z] 	/var/lib/buildkite-agent/.gvm/versions/go1.24.2.linux.amd64/src/testing/benchmark.go:219 +0x190
[2025-05-08T12:21:20Z] testing.(*B).run1.func1()
[2025-05-08T12:21:20Z] 	/var/lib/buildkite-agent/.gvm/versions/go1.24.2.linux.amd64/src/testing/benchmark.go:245 +0x48
[2025-05-08T12:21:20Z] created by testing.(*B).run1 in goroutine 1
[2025-05-08T12:21:20Z] 	/var/lib/buildkite-agent/.gvm/versions/go1.24.2.linux.amd64/src/testing/benchmark.go:238 +0x90
[2025-05-08T12:21:20Z] exit status 2
[2025-05-08T12:21:20Z] FAIL	github.com/elastic/apm-server/internal/publish
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

```
make bench
```

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
