### PR TITLE
smoke: Increase Rocky-8 instance type to `t4g.micro`

### DIFF
--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -24,7 +24,7 @@ locals {
     "al2023-ami-2023.*-x86_64"        = "t3a.micro"
     "RHEL-8"                          = "t4g.micro" # RHEL doesn't support nano instances
     "RHEL-9"                          = "t4g.micro" # RHEL doesn't support nano instances
-    "Rocky-8-EC2-Base"                = "t4g.nano"
+    "Rocky-8-EC2-Base"                = "t4g.micro" # Larger instance size to improve test reliability
     "Rocky-9-EC2-Base"                = "t4g.nano"
     "AlmaLinux OS 8"                  = "t4g.nano"
     "AlmaLinux OS 9"                  = "t4g.nano"


### PR DESCRIPTION
## Motivation/summary
Smoke tests have intermittent `terraform apply` failures for this OS. Using a larger instance type to improve test reliability.


## Checklist


## How to test these changes
Ran `smoke-test-os` workflow with larger instance. Unable to reproduce the issue. 
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/8f463b8e-0ba5-4d72-acb3-5b41a15af2d5" />


## Related issues

Closes https://github.com/elastic/apm-server/issues/16518