### PR TITLE
smoke: Restore accidentally deleted generate-smoke-tests-list action

### DIFF
--- a/.github/workflows/generate-smoke-tests-list/action.yml
+++ b/.github/workflows/generate-smoke-tests-list/action.yml
@@ -1,0 +1,27 @@
+---
+
+name: generate-smoke-tests-list
+description: Generate smoke tests list
+
+outputs:
+  tests:
+    description: "List of smoke tests"
+    value: ${{ steps.generate.outputs.tests }}
+  tests_legacy:
+    description: "List of legacy smoke tests"
+    value: ${{ steps.generate.outputs.tests_legacy }}
+  date:
+    description: "Current date"
+    value: ${{ steps.generate.outputs.date }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: generate
+      name: Generate matrix and date
+      run: |
+        # remove the full path and use a relative path instead to be github runner agnostic
+        echo "tests=$(make smoketest/discover | sed "s#${GITHUB_WORKSPACE}/#./#g")" >> "${GITHUB_OUTPUT}"
+        echo "tests_legacy=$(make smoketest/discover-legacy | sed "s#${GITHUB_WORKSPACE}/#./#g")" >> "${GITHUB_OUTPUT}"
+        echo "date=$(date +%s)" >> "${GITHUB_OUTPUT}"
+      shell: 'bash'


### PR DESCRIPTION
## Motivation/summary

This file that is used by `smoke-tests-os-sched` got accidentally deleted in https://github.com/elastic/apm-server/pull/17085.

## How to test these changes

Run smoke test OS sched workflow: 
