### PR TITLE
smoke: Fix steps using deleted action & workflow typo

### DIFF
--- a/.github/workflows/integration-server-test.yml
+++ b/.github/workflows/integration-server-test.yml
@@ -82,7 +82,7 @@ jobs:
           secrets: |-
             EC_API_KEY:elastic-observability/elastic-cloud-observability-team-pro-api-key
       - name: "Run standalone-to-managed tests"
-        working-directory: ${{ github.workspace }}/integrationservertest
+        working-directory: ${{ github.workspace }}
         run: |
           export TF_VAR_CREATED_DATE=$(date +%s)
           SCENARIO="${{ matrix.scenario }}" make integration-server-standalone-test

--- a/.github/workflows/smoke-tests-os.yml
+++ b/.github/workflows/smoke-tests-os.yml
@@ -18,15 +18,12 @@ jobs:
     name: Generate smoke tests list
     runs-on: ubuntu-latest
     outputs:
-      tests: ${{ steps.generate.outputs.tests }}
       date: ${{ steps.generate.outputs.date }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          ref: ${{ inputs.branch }}
       - id: generate
-        name: Generate matrix and date
-        uses: ./.github/workflows/generate-smoke-tests-list
+        name: Generate date
+        run: echo "date=$(date +%s)" >> "${GITHUB_OUTPUT}"
+        shell: bash
 
   smoke-tests-os:
     name: Run smoke tests OS

--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ endif
 ifndef SCENARIO
 	$(error SCENARIO is not set)
 endif
-	@cd integrationservertest && go test -run=TestUpgrade.*/.*/$(SCENARIO) -v -timeout=60m -cleanup-on-failure=false -target="pro" -upgrade-path="$(UPGRADE_PATH)}" ./
+	@cd integrationservertest && go test -run=TestUpgrade.*/.*/$(SCENARIO) -v -timeout=60m -cleanup-on-failure=false -target="pro" -upgrade-path="$(UPGRADE_PATH)" ./
 
 # Run integration server upgrade test on all scenarios
 .PHONY: integration-server-upgrade-test-all
@@ -371,7 +371,7 @@ integration-server-upgrade-test-all:
 ifndef UPGRADE_PATH
 	$(error UPGRADE_PATH is not set)
 endif
-	@cd integrationservertest && go test -run=TestUpgrade_UpgradePath -v -timeout=60m -cleanup-on-failure=false -target="pro" -upgrade-path="$(UPGRADE_PATH)}" ./
+	@cd integrationservertest && go test -run=TestUpgrade_UpgradePath -v -timeout=60m -cleanup-on-failure=false -target="pro" -upgrade-path="$(UPGRADE_PATH)" ./
 
 # Run integration server standalone test on one scenario - Managed7 / Managed8 / Managed9
 .PHONY: integration-server-standalone-test

--- a/integrationservertest/internal/ech/version.go
+++ b/integrationservertest/internal/ech/version.go
@@ -259,7 +259,7 @@ func parseVersionPrefix(prefix string) (looseVersion, error) {
 	// First match is the whole string, last match is the suffix, total 5
 	matches := looseVersionRegex.FindStringSubmatch(prefix)
 	if len(matches) == 0 || len(matches) > 5 {
-		return looseVersion{}, errors.New("invalid prefix format")
+		return looseVersion{}, fmt.Errorf("invalid prefix format: %s", prefix)
 	}
 
 	major, err := strconv.ParseUint(matches[1], 10, 64)


### PR DESCRIPTION
## Motivation/summary

Previous PR to remove some old smoke tests stuff failed to remove one of the steps that reference a deleted file: https://github.com/elastic/apm-server/pull/17085.

This PR removes that unnecessary step, and also fixes some workflow typo.

## How to test these changes

Run `smoke-tests-os`: https://github.com/elastic/apm-server/actions/runs/15560510766.
Run `integration-server-tests`: https://github.com/elastic/apm-server/actions/runs/15561173496.
