### PR TITLE
smoke: Remove ubuntu 18.04 from os_matrix.sh since it is no longer available

### DIFF
--- a/testing/smoke/os_matrix.sh
+++ b/testing/smoke/os_matrix.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 os_names=(
-    "ubuntu-bionic-18.04-arm64-server"
     "ubuntu-focal-20.04-arm64-server"
     "ubuntu-jammy-22.04-arm64-server"
     "debian-11-arm64"


### PR DESCRIPTION
## Motivation/summary
Smoke test for 8.x versions have been consistently failing because the ubuntu 18.04 OS is no longer available on AWS. 

## How to test these changes
1. Ran smoke-testd-os workflow on new branch 
<img width="1673" alt="image" src="https://github.com/user-attachments/assets/54bea612-6f1c-44a1-b032-f3d001f5234a" />


## Related issues

Closes https://github.com/elastic/apm-server/issues/17171
