### PR TITLE
fix: purge noisy libxml2 from ubi image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -97,6 +97,9 @@ RUN chown -R 1000:1000 /usr/share/apm-server
 # use rpm to ignore ubi images
 RUN rpm -v || (dpkg -P --force-depends libgssapi-krb5-2 libtirpc3 libnsl2 libkrb5-3 libk5crypto3 libkrb5support0 && \
     rm /var/log/dpkg.log)
+# remove unnecessary packages in ubi-based images
+# use dpkg to ignore ubuntu images
+RUN dpkg --version || (rpm -v -e --nodeps libxml2)
 
 USER apm-server
 EXPOSE 8200


### PR DESCRIPTION
## Motivation/summary

Remove noisy package `libxml2@2.9.13-9.el9_6` from APM Server UBI image.

This PR only targets `8.x` versions.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
