### PR TITLE
fix: close default apm tracer

### DIFF
--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -124,6 +124,12 @@ type RunnerParams struct {
 func NewRunner(args RunnerParams) (*Runner, error) {
 	fips140.CheckFips()
 
+	// the default tracer is leaking and its background
+	// goroutine is spamming requests to this apm server (default endpoint)
+	// If TLS is enabled it causes "http request sent to https endpoint".
+	// Close the default tracer since it's not used.
+	apm.DefaultTracer().Close()
+
 	var unpackedConfig struct {
 		APMServer  *agentconfig.C        `config:"apm-server"`
 		Output     agentconfig.Namespace `config:"output"`


### PR DESCRIPTION
## Motivation/summary

the default tracer is leaking and its background goroutine spamming requests to this apm server (default endpoint) If TLS is enabled it causes 'http request sent to https endpoint'.

Close the default tracer since it's not used.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- run apm-server with tls enabled
- enable self instrumentation
- check the message is not logged on startup

## Related issues


