### PR TITLE
Include FIPS distribution information in version command output

### DIFF
--- a/internal/beatcmd/version.go
+++ b/internal/beatcmd/version.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/apm-server/internal/version"
 	"github.com/elastic/beats/v7/libbeat/common/cli"
+	beatVersion "github.com/elastic/beats/v7/libbeat/version"
 )
 
 var versionCommand = &cobra.Command{
@@ -40,9 +41,9 @@ var versionCommand = &cobra.Command{
 		}
 
 		fmt.Fprintf(cmd.OutOrStdout(),
-			"apm-server version %s (%s/%s) [%s]\n",
+			"apm-server version %s (%s/%s) [%s] (FIPS-distribution: %v)\n",
 			version.VersionWithQualifier(), runtime.GOOS, runtime.GOARCH,
-			buf.String(),
+			buf.String(), beatVersion.FIPSDistribution,
 		)
 		return nil
 	}),


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

This PR enhances the output of the `version` CLI sub-command to include whether the binary is FIPS-capable or not.  FIPS-capable binaries will report `FIPS-distribution: true` in the `version` sub-command's output.

This output is consistent with the output of the `version` sub-command for Beats and Elastic Agent.

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

Build a non-FIPS-capable binary and check that the `version` sub-command output contains `(FIPS-distribution: false)`.
```
$ make apm-server
$ ./apm-server version
```

Build a FIPS-capable binary and check that the `version` sub-command output contains `(FIPS-distribution: true)`.
```
$ make apm-server-fips
$ ./apm-server-fips version
```
