### PR TITLE
tbs: update metric creation to avoid conflicts with name prefix 'apm-server.sampling'

### DIFF
--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -22,9 +22,9 @@ type Config struct {
 	// tail-sampled trace events.
 	BatchProcessor modelpb.BatchProcessor
 
-	// MeterProvider holds a metric.MeterProvider that can be used for
-	// creating metrics.
-	MeterProvider metric.MeterProvider
+	// Meter holds a metric.Meter that can be used for
+	// creating metrics
+	Meter metric.Meter
 
 	LocalSamplingConfig
 	RemoteSamplingConfig

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -62,25 +62,23 @@ func NewProcessor(config Config, logger *logp.Logger) (*Processor, error) {
 		return nil, errors.Wrap(err, "invalid tail-sampling config")
 	}
 
-	meter := config.MeterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/sampling")
-
 	logger = logger.Named(logs.Sampling)
 	p := &Processor{
 		config:            config,
 		logger:            logger,
 		rateLimitedLogger: logger.WithOptions(logs.WithRateLimit(loggerRateLimit)),
-		groups:            newTraceGroups(meter, config.Policies, config.MaxDynamicServices, config.IngestRateDecayFactor),
+		groups:            newTraceGroups(config.Meter, config.Policies, config.MaxDynamicServices, config.IngestRateDecayFactor),
 		eventStore:        config.Storage,
 		stopping:          make(chan struct{}),
 		stopped:           make(chan struct{}),
 	}
 
-	p.eventMetrics.processed, _ = meter.Int64Counter("apm-server.sampling.tail.events.processed")
-	p.eventMetrics.dropped, _ = meter.Int64Counter("apm-server.sampling.tail.events.dropped")
-	p.eventMetrics.stored, _ = meter.Int64Counter("apm-server.sampling.tail.events.stored")
-	p.eventMetrics.sampled, _ = meter.Int64Counter("apm-server.sampling.tail.events.sampled")
-	p.eventMetrics.headUnsampled, _ = meter.Int64Counter("apm-server.sampling.tail.events.head_unsampled")
-	p.eventMetrics.failedWrites, _ = meter.Int64Counter("apm-server.sampling.tail.events.failed_writes")
+	p.eventMetrics.processed, _ = config.Meter.Int64Counter("apm-server.sampling.tail.events.processed")
+	p.eventMetrics.dropped, _ = config.Meter.Int64Counter("apm-server.sampling.tail.events.dropped")
+	p.eventMetrics.stored, _ = config.Meter.Int64Counter("apm-server.sampling.tail.events.stored")
+	p.eventMetrics.sampled, _ = config.Meter.Int64Counter("apm-server.sampling.tail.events.sampled")
+	p.eventMetrics.headUnsampled, _ = config.Meter.Int64Counter("apm-server.sampling.tail.events.head_unsampled")
+	p.eventMetrics.failedWrites, _ = config.Meter.Int64Counter("apm-server.sampling.tail.events.failed_writes")
 
 	return p, nil
 }

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -846,8 +846,9 @@ func newTempdirConfig(tb testing.TB) testConfig {
 		},
 	))
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("test-meter-sampling")
 
-	db, err := eventstorage.NewStorageManager(tempdir, logptest.NewTestingLogger(tb, ""), eventstorage.WithMeterProvider(mp))
+	db, err := eventstorage.NewStorageManager(tempdir, logptest.NewTestingLogger(tb, ""), eventstorage.WithMeter(meter))
 	require.NoError(tb, err)
 	tb.Cleanup(func() { db.Close() })
 
@@ -856,7 +857,7 @@ func newTempdirConfig(tb testing.TB) testConfig {
 		metricReader: reader,
 		Config: sampling.Config{
 			BatchProcessor: modelpb.ProcessBatchFunc(func(context.Context, *modelpb.Batch) error { return nil }),
-			MeterProvider:  mp,
+			Meter:          meter,
 			LocalSamplingConfig: sampling.LocalSamplingConfig{
 				FlushInterval:         time.Second,
 				MaxDynamicServices:    1000,


### PR DESCRIPTION
## Motivation/summary

Currently `apm-server.sampling.tail.storage.lsm_size` and `apm-server.sampling.tail.dynamic_service_groups` are never reported together. 

Testing locally this is caused because both sets of metrics use the same namespace `apm-server.sampling` but they are created using different instances of a Meter.  

I opted to create a common instance of the meter to avoid renaming the metrics. This seems to not align with the  [docs](https://pkg.go.dev/go.opentelemetry.io/otel/metric@v1.37.0#MeterProvider.Meter) around a Meter but I do not think we want to change the metric names. Let me know if you feel otherwise

## Checklist

- [ ] View individual metrics documents to confirm reported metrics are correct

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

1. Run apm-server with TBS enabled
2. Send data to the server `./sendotlp -insecure -endpoint=http://localhost:8200 -secret-token=<token>`
3. View metrics via the stats endpoint (http://localhost:5066/stats?pretty) . `storage` should be visible along with other metrics under `apm-server.sampling.tail`

```json
"sampling": {
	"tail": {
		"dynamic_service_groups": 1,
		"events": {
			"processed": 3,
			"stored": 3
		},
		"storage": {
			"lsm_size": 7572,
			"value_log_size": 0
		}
	}
}
```

## Related issues

Closes https://github.com/elastic/apm-server/issues/17342
