### PR TITLE
iserver-test: Fix upgrade config lazy rollover

### DIFF
--- a/integrationservertest/upgrade-config.yaml
+++ b/integrationservertest/upgrade-config.yaml
@@ -14,3 +14,4 @@ lazy-rollover-with-exceptions:
   8.19:
   9.0:
   9.1:
+  9.2:

--- a/integrationservertest/upgrade-config.yaml
+++ b/integrationservertest/upgrade-config.yaml
@@ -13,7 +13,4 @@ lazy-rollover-with-exceptions:
   8.17:
   8.19:
   9.0:
-  # 8.19 and 9.1 have the same template due to
-  # https://github.com/elastic/elasticsearch/pull/128913.
   9.1:
-    - "8.19"

--- a/integrationservertest/upgrade-config.yaml
+++ b/integrationservertest/upgrade-config.yaml
@@ -15,3 +15,4 @@ lazy-rollover-with-exceptions:
   9.0:
   9.1:
   9.2:
+    - "9.1"


### PR DESCRIPTION
## Motivation/summary

8.19 and 9.1 no longer have the same apm-data resource version after https://github.com/elastic/elasticsearch/pull/130478 and https://github.com/elastic/elasticsearch/pull/130477 have been merged. So, it is expected that they will have lazy rollover across upgrades.

## How to test these changes

Run workflow: https://github.com/elastic/apm-server/actions/runs/16112715129.