### PR TITLE
codeowners: only care for the workflows subfolder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @elastic/obs-ds-intake-services
 
 # Sub-directories/files ownership
-/.github @elastic/obs-ds-intake-services @elastic/observablt-ci
+/.github/workflows @elastic/obs-ds-intake-services @elastic/observablt-ci


### PR DESCRIPTION
## Motivation/summary

We, @elastic/observablt-ci , can help with the github workflows reviews, hence we only need to be owners of those files, `dependabot` removed the `reviewers` configuration. So they encourage using CODEOWNERS instead.

https://github.com/elastic/apm-server/pull/17408 introduced the former change

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
