### PR TITLE
iserver-test: Fix standalone test rollover

### DIFF
--- a/integrationservertest/standalone_test.go
+++ b/integrationservertest/standalone_test.go
@@ -18,6 +18,7 @@
 package integrationservertest
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/elastic/apm-server/integrationservertest/internal/asserts"
@@ -37,21 +38,26 @@ func TestStandaloneManaged_7_17_to_8_x_to_9_x_Snapshot(t *testing.T) {
 		return
 	}
 
+	config, err := parseConfig(upgradeConfigFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Run("Managed7", func(t *testing.T) {
 		t.Parallel()
-		runner := managed7Runner(from7, to8, to9)
+		runner := managed7Runner(from7, to8, to9, config)
 		runner.Run(t)
 	})
 
 	t.Run("Managed8", func(t *testing.T) {
 		t.Parallel()
-		runner := managed8Runner(from7, to8, to9)
+		runner := managed8Runner(from7, to8, to9, config)
 		runner.Run(t)
 	})
 
 	t.Run("Managed9", func(t *testing.T) {
 		t.Parallel()
-		runner := managed9Runner(from7, to8, to9)
+		runner := managed9Runner(from7, to8, to9, config)
 		runner.Run(t)
 	})
 }
@@ -74,7 +80,26 @@ var (
 	}
 )
 
-func managed7Runner(fromVersion7, toVersion8, toVersion9 ech.Version) testStepsRunner {
+func expectationsFor9x(
+	version8 ech.Version,
+	version9 ech.Version,
+	expect8 map[string]asserts.DataStreamExpectation,
+	config upgradeTestConfig,
+) map[string]asserts.DataStreamExpectation {
+	expect9 := maps.Clone(expect8)
+	if config.HasLazyRollover(version8, version9) {
+		for k, v := range expect9 {
+			expect9[k] = asserts.DataStreamExpectation{
+				PreferIlm:        v.PreferIlm,
+				DSManagedBy:      v.DSManagedBy,
+				IndicesManagedBy: append(v.IndicesManagedBy, managedByILM),
+			}
+		}
+	}
+	return expect9
+}
+
+func managed7Runner(fromVersion7, toVersion8, toVersion9 ech.Version, config upgradeTestConfig) testStepsRunner {
 	expect8 := map[string]asserts.DataStreamExpectation{
 		// These data streams are created in 7.x as well, so when we ingest
 		// again in 8.x, they will be rolled over.
@@ -89,20 +114,7 @@ func managed7Runner(fromVersion7, toVersion8, toVersion9 ech.Version) testStepsR
 		"metrics-apm.service_summary.1m-%s":     expectILM,
 		"metrics-apm.transaction.1m-%s":         expectILM,
 	}
-	expect9 := map[string]asserts.DataStreamExpectation{
-		// These data streams are created in 7.x as well, so after ingestion in
-		// 8.x and 9.x, we will have 2 rollovers.
-		"traces-apm-%s":                     expectILMRolloverTwice,
-		"metrics-apm.app.opbeans_python-%s": expectILMRolloverTwice,
-		"metrics-apm.internal-%s":           expectILMRolloverTwice,
-		"logs-apm.error-%s":                 expectILMRolloverTwice,
-		// These data streams are only created in 8.x, and they roll over again
-		// in 9.x.
-		"metrics-apm.service_destination.1m-%s": expectILMRollover,
-		"metrics-apm.service_transaction.1m-%s": expectILMRollover,
-		"metrics-apm.service_summary.1m-%s":     expectILMRollover,
-		"metrics-apm.transaction.1m-%s":         expectILMRollover,
-	}
+	expect9 := expectationsFor9x(toVersion8, toVersion9, expect8, config)
 
 	// These data streams are created in 7.x, but not used in 8.x and 9.x,
 	// so we ignore them to avoid wrong assertions.
@@ -163,9 +175,9 @@ func managed7Runner(fromVersion7, toVersion8, toVersion9 ech.Version) testStepsR
 	}
 }
 
-func managed8Runner(fromVersion7, toVersion8, toVersion9 ech.Version) testStepsRunner {
+func managed8Runner(fromVersion7, toVersion8, toVersion9 ech.Version, config upgradeTestConfig) testStepsRunner {
 	expect8 := dataStreamsExpectations(expectILM)
-	expect9 := dataStreamsExpectations(expectILMRollover)
+	expect9 := expectationsFor9x(toVersion8, toVersion9, expect8, config)
 
 	// These data streams are created in 7.x, but not used in 8.x and 9.x,
 	// so we ignore them to avoid wrong assertions.
@@ -220,9 +232,9 @@ func managed8Runner(fromVersion7, toVersion8, toVersion9 ech.Version) testStepsR
 	}
 }
 
-func managed9Runner(fromVersion7, toVersion8, toVersion9 ech.Version) testStepsRunner {
+func managed9Runner(fromVersion7, toVersion8, toVersion9 ech.Version, config upgradeTestConfig) testStepsRunner {
 	expect8 := dataStreamsExpectations(expectILM)
-	expect9 := dataStreamsExpectations(expectILMRollover)
+	expect9 := expectationsFor9x(toVersion8, toVersion9, expect8, config)
 
 	return testStepsRunner{
 		Target: *target,

--- a/integrationservertest/upgrade_test.go
+++ b/integrationservertest/upgrade_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/elastic/apm-server/integrationservertest/internal/ech"
 )
 
+const upgradeConfigFileName = "upgrade-config.yaml"
+
 func formatUpgradePath(p string) string {
 	splits := strings.Split(p, ",")
 	for i := range splits {
@@ -72,7 +74,7 @@ func testUpgrade(t *testing.T, upgradePathStr string, versionFetcher func(*testi
 		versions = append(versions, curr)
 	}
 
-	config, err := parseConfig("upgrade-config.yaml")
+	config, err := parseConfig(upgradeConfigFileName)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Motivation/summary

Standalone test rollover expectation was previously hardcoded. This PR removes the hardcoding (specifically for 8.x to 9.x upgrade), by using the upgrade config lazy rollover setting.

## How to test these changes

Run workflow: https://github.com/elastic/apm-server/actions/runs/16136046314.
