### PR TITLE
Revert "[8.19] (backport #17154) tbs: Update storage metrics to be reported synchronously in the existing `runDiskUsageLoop` method"

### DIFF
--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -38,8 +38,9 @@ const (
 
 var (
 	// badgerDB holds the badger database to use when tail-based sampling is configured.
-	badgerMu sync.Mutex
-	badgerDB *eventstorage.StorageManager
+	badgerMu                   sync.Mutex
+	badgerDB                   *eventstorage.StorageManager
+	badgerDBMetricRegistration metric.Registration
 
 	storageMu sync.Mutex
 	storage   *eventstorage.ManagedReadWriter
@@ -168,15 +169,22 @@ func getBadgerDB(storageDir string, mp metric.MeterProvider) (*eventstorage.Stor
 	badgerMu.Lock()
 	defer badgerMu.Unlock()
 	if badgerDB == nil {
-		var opts []eventstorage.StorageManagerOptions
-		if mp != nil {
-			opts = append(opts, eventstorage.WithMeterProvider(mp))
-		}
-		sm, err := eventstorage.NewStorageManager(storageDir, opts...)
+		sm, err := eventstorage.NewStorageManager(storageDir)
 		if err != nil {
 			return nil, err
 		}
 		badgerDB = sm
+
+		meter := mp.Meter("github.com/elastic/apm-server/x-pack/apm-server")
+		lsmSizeGauge, _ := meter.Int64ObservableGauge("apm-server.sampling.tail.storage.lsm_size")
+		valueLogSizeGauge, _ := meter.Int64ObservableGauge("apm-server.sampling.tail.storage.value_log_size")
+
+		badgerDBMetricRegistration, _ = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
+			lsmSize, valueLogSize := sm.Size()
+			o.ObserveInt64(lsmSizeGauge, lsmSize)
+			o.ObserveInt64(valueLogSizeGauge, valueLogSize)
+			return nil
+		}, lsmSizeGauge, valueLogSizeGauge)
 	}
 	return badgerDB, nil
 }
@@ -256,6 +264,10 @@ func wrapServer(args beater.ServerParams, runServer beater.RunServerFunc) (beate
 // called concurrently with opening badger.DB/accessing the badgerDB global,
 // so it does not need to hold badgerMu.
 func closeBadger() error {
+	if badgerDBMetricRegistration != nil {
+		badgerDBMetricRegistration.Unregister()
+		badgerDBMetricRegistration = nil
+	}
 	if badgerDB != nil {
 		db := badgerDB
 		badgerDB = nil


### PR DESCRIPTION
These changes attempted to fix reporting issue for `lsm_size` metrics where we believed were caused by the use of Observable OTEL metrics. The changes introduced a regression where we observed the `lsm_size` metrics less frequently than before.

After updating metrics collection to remove conflicts (https://github.com/elastic/apm-server/pull/17525), we determined this was the root issue that was contributing to the infrequent `lsm_size` metrics (not the Observable OTEL metrics).  The changes in this PR fixed the regression mention above. 

The prior implementation with Observable metrics is preferred so we will revert elastic/apm-server#17275