### PR TITLE
chore: Remove stale comment about reloader multierror

### DIFF
--- a/internal/beatcmd/reloader.go
+++ b/internal/beatcmd/reloader.go
@@ -142,8 +142,8 @@ func (r *Reloader) Run(ctx context.Context) error {
 }
 
 // reloadInput (re)loads input configuration.
-// It returns a *multierror.MultiError as libbeat manager error handling is tightly coupled
-// with its own reloadable list implementation in libbeat/cfgfile/list.go.
+// It has to return a joined error similar to the libbeat reloadable list implementation in libbeat/cfgfile/list.go,
+// such that the returned error is corrected parsed by libbeat managerV2.
 //
 // Note: reloadInputs may be called before the Reloader is running.
 func (r *Reloader) reloadInputs(configs []*reload.ConfigWithMeta) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Remove stale comment after bumping beats in https://github.com/elastic/apm-server/pull/15458

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
