### PR TITLE
iserver-test: Remove 9.1 from 9.2 lazy rollover exception

### DIFF
--- a/integrationservertest/upgrade-config.yaml
+++ b/integrationservertest/upgrade-config.yaml
@@ -15,4 +15,3 @@ lazy-rollover-with-exceptions:
   9.0:
   9.1:
   9.2:
-    - "9.1"


### PR DESCRIPTION
## Motivation/summary

PR https://github.com/elastic/elasticsearch/pull/131296 made changes to apm-data plugin for 9.2, so 9.1 and 9.2 no longer share resource version.

## How to test these changes

Run workflow.
