### PR TITLE
iserver-test: Skip run-upgrade-bc if upgrade_paths is empty

### DIFF
--- a/.github/workflows/integration-server-test.yml
+++ b/.github/workflows/integration-server-test.yml
@@ -83,7 +83,7 @@ jobs:
           SCENARIO="${{ matrix.scenario }}" UPGRADE_PATH="${{ matrix.upgrade-path }}" SNAPSHOT=true make integration-server-test/upgrade
 
   run-upgrade-bc:
-    if: ${{ !contains(inputs.run-upgrade-bc-tests, 'false') }}
+    if: ${{ !contains(inputs.run-upgrade-bc-tests, 'false') && needs.prepare.outputs.upgrade_paths != '[]' }}
     name: Upgrade tests (BC)
     runs-on: ubuntu-latest
     needs: prepare


### PR DESCRIPTION
## Motivation/summary

Integration server test fails when there are no BCs. Skip BC tests if there are no BCs.

## How to test these changes

Run workflow: https://github.com/elastic/apm-server/actions/runs/16612788970

