### PR TITLE
fix: do not try to create apm-serve registry if it exists

### DIFF
--- a/internal/beater/telemetry.go
+++ b/internal/beater/telemetry.go
@@ -25,7 +25,7 @@ import (
 // recordAPMServerConfig records dynamic APM Server config properties for telemetry.
 // This should be called once each time runServer is called.
 func recordAPMServerConfig(cfg *config.Config, stateRegistry *monitoring.Registry) {
-	apmRegistry := stateRegistry.NewRegistry("apm-server")
+	apmRegistry := stateRegistry.GetOrCreateRegistry("apm-server")
 	monitoring.NewBool(apmRegistry, "rum.enabled").Set(cfg.RumConfig.Enabled)
 	monitoring.NewBool(apmRegistry, "api_key.enabled").Set(cfg.AgentAuth.APIKey.Enabled)
 	monitoring.NewBool(apmRegistry, "kibana.enabled").Set(cfg.Kibana.Enabled)


### PR DESCRIPTION
## Motivation/summary

`apm-server` registry could already exist, causing a failure on agent reload when trying to be recreated

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
