### PR TITLE
refactor: replace NewRegistry with safer GetOrCreateRegistry

### DIFF
--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -477,20 +477,20 @@ func (b *Beat) registerStateMetrics() {
 	stateRegistry := b.Monitoring.StateRegistry()
 
 	// state.service
-	serviceRegistry := stateRegistry.NewRegistry("service")
+	serviceRegistry := stateRegistry.GetOrCreateRegistry("service")
 	monitoring.NewString(serviceRegistry, "version").Set(b.Info.Version)
 	monitoring.NewString(serviceRegistry, "name").Set(b.Info.Beat)
 	monitoring.NewString(serviceRegistry, "id").Set(b.Info.ID.String())
 
 	// state.beat
-	beatRegistry := stateRegistry.NewRegistry("beat")
+	beatRegistry := stateRegistry.GetOrCreateRegistry("beat")
 	monitoring.NewString(beatRegistry, "name").Set(b.Info.Name)
 
 	// state.host
 	monitoring.NewFunc(stateRegistry, "host", host.ReportInfo("" /* don't use FQDN */), monitoring.Report)
 
 	// state.management
-	managementRegistry := stateRegistry.NewRegistry("management")
+	managementRegistry := stateRegistry.GetOrCreateRegistry("management")
 	monitoring.NewBool(managementRegistry, "enabled").Set(b.Manager.Enabled())
 }
 
@@ -776,7 +776,7 @@ func (b *Beat) registerClusterUUIDFetching() (func(), error) {
 // Build and return a callback to fetch the Elasticsearch cluster_uuid for monitoring
 func (b *Beat) clusterUUIDFetchingCallback() elasticsearch.ConnectCallback {
 	stateRegistry := b.Monitoring.StateRegistry()
-	elasticsearchRegistry := stateRegistry.NewRegistry("outputs.elasticsearch")
+	elasticsearchRegistry := stateRegistry.GetOrCreateRegistry("outputs.elasticsearch")
 	clusterUUIDRegVar := monitoring.NewString(elasticsearchRegistry, "cluster_uuid")
 
 	callback := func(esClient *eslegclient.Connection, _ *logp.Logger) error {
@@ -814,7 +814,7 @@ func (b *Beat) setupMonitoring() (report.Reporter, error) {
 	// Expose monitoring.cluster_uuid in state API
 	if monitoringClusterUUID != "" {
 		stateRegistry := b.Monitoring.StateRegistry()
-		monitoringRegistry := stateRegistry.NewRegistry("monitoring")
+		monitoringRegistry := stateRegistry.GetOrCreateRegistry("monitoring")
 		clusterUUIDRegVar := monitoring.NewString(monitoringRegistry, "cluster_uuid")
 		clusterUUIDRegVar.Set(monitoringClusterUUID)
 	}

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -726,7 +726,7 @@ func (s *Runner) newFinalBatchProcessor(
 ) (modelpb.BatchProcessor, func(context.Context) error, error) {
 	if s.elasticsearchOutputConfig == nil {
 		s.beatMonitoring.StatsRegistry().Remove("libbeat")
-		libbeatMonitoringRegistry := s.beatMonitoring.StatsRegistry().NewRegistry("libbeat")
+		libbeatMonitoringRegistry := s.beatMonitoring.StatsRegistry().GetOrCreateRegistry("libbeat")
 		return s.newLibbeatFinalBatchProcessor(tracer, libbeatMonitoringRegistry, logger)
 	}
 

--- a/internal/beater/beater_test.go
+++ b/internal/beater/beater_test.go
@@ -122,7 +122,7 @@ func sourcemapSearchResponseBody(name string, version string, bundlePath string)
 func TestQueryClusterUUIDRegistriesExist(t *testing.T) {
 	stateRegistry := monitoring.NewRegistry()
 
-	elasticsearchRegistry := stateRegistry.NewRegistry("outputs.elasticsearch")
+	elasticsearchRegistry := stateRegistry.GetOrCreateRegistry("outputs.elasticsearch")
 	monitoring.NewString(elasticsearchRegistry, "cluster_uuid")
 
 	const clusterUUID = "abc123"


### PR DESCRIPTION
## Motivation/summary

replace remaining `NewRegistry` with `GetOrCreateRegistry`

those calls should not panic but replace them with a safer alternative to prevent future issues

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/17905
