### PR TITLE
Release: bump release version manually

### DIFF
--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "9.1.1"
+const version = "9.1.2"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "9.1.1"
+const Version = "9.1.2"


### PR DESCRIPTION
For some reason the https://github.com/elastic/apm-server/releases/tag/v9.1.1 release didn't bump the versions correctly