### PR TITLE
Fix docker image permission denied on ca-bundle.crt

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -80,8 +80,9 @@ ENV BEAT_STRICT_PERMS=false
 
 COPY --chmod=0755 packaging/docker/docker-entrypoint /usr/local/bin/docker-entrypoint
 COPY --chmod=0755 licenses/ELASTIC-LICENSE-2.0.txt NOTICE.txt /licenses/
-RUN mkdir -p -m 755 /etc/pki/tls/certs
-COPY --chmod=0644 --from=builder-certs /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
+
+# Do not explcitly set chmod, such that directory is 0755 and file is 0644
+COPY --from=builder-certs /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 
 # Copy files world-readable, and create the data directory world-writeable,
 # to permit running the container with arbitrary UIDs and GIDs.

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -80,6 +80,7 @@ ENV BEAT_STRICT_PERMS=false
 
 COPY --chmod=0755 packaging/docker/docker-entrypoint /usr/local/bin/docker-entrypoint
 COPY --chmod=0755 licenses/ELASTIC-LICENSE-2.0.txt NOTICE.txt /licenses/
+RUN mkdir -p -m 755 /etc/pki/tls/certs
 COPY --chmod=0644 --from=builder-certs /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 
 # Copy files world-readable, and create the data directory world-writeable,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Fix /etc/pki created with file mod 0644 instead of 0755, causing ca-bundle to be inaccessible. This is a regression from #16956 

Fix to be backported to all active 8.x.

changelog: "Fix a 8.18.1 and 8.19.0 regression in docker image causing permission denied when accessing /etc/pki/tls/certs/ca-bundle.crt due to incorrect directory permissions"

Ubuntu:

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/8fd63186-a688-4f26-b2d6-5fa51012bf07" />

UBI:

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/8c385177-0ca4-4168-b3c8-ed8a32125945" />


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

```
carson@carson-elastic-t:~/issues/apm-server-18092$ docker run -it --rm elastic/apm-server:8.18.0 /bin/sh -c 'ls -al /etc/pki/tls/certs/ca-bundle.crt'
-rw-r--r-- 1 root root 215902 Apr 10 15:18 /etc/pki/tls/certs/ca-bundle.crt
carson@carson-elastic-t:~/issues/apm-server-18092$ docker run -it --rm elastic/apm-server:8.18.1 /bin/sh -c 'ls -al /etc/pki/tls/certs/ca-bundle.crt'
ls: cannot access '/etc/pki/tls/certs/ca-bundle.crt': Permission denied
```

Run this command with build candidate docker image when ready.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes #18092