### PR TITLE
ci: add dependency bumps to 8.19 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,8 @@ updates:
         patterns:
           - "*"
   # go dependencies 8.x branch
-  - package-ecosystem: "gomod-8.19"
+  - package-ecosystem: "gomod"
+    target-branch: "8.19"
     directory: "/"
     ignore:
       - dependency-name: "github.com/elastic/beats/v7"
@@ -52,7 +53,8 @@ updates:
         patterns:
           - "*"
   # docker 8.x branch
-  - package-ecosystem: "docker-8.19"
+  - package-ecosystem: "docker"
+    target-branch: "8.19"
     directory: "/packaging/docker/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Motivation/summary

add a new entry in `.github/dependabot.yml` for Go module and docker images ecosystem updates targeting the "8.19" branch.

dependabot only targets main but 8.19 will keep being supported in the future so we want to bump dependencies to get bugfixes

use a weekly interval and group dependencies together to avoid too much PR noise

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/18152
