### PR TITLE
Remove last remaining NewRegistry method call

### DIFF
--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -965,9 +965,12 @@ func queryClusterUUID(ctx context.Context, esClient *elasticsearch.Client, state
 	// Running under elastic-agent, the callback linked above is not
 	// registered until later, meaning we need to check and instantiate the
 	// registries if they don't exist.
-	elasticsearchRegistry := stateRegistry.GetRegistry(outputES)
+	elasticsearchRegistry := stateRegistry.GetOrCreateRegistry(outputES)
 	if elasticsearchRegistry == nil {
-		elasticsearchRegistry = stateRegistry.NewRegistry(outputES)
+		// This can only happen if "outputs.elasticsearch" was already created as
+		// a non-registry (scalar) value, but in that unlikely chance, let's still
+		// report a comprehensible error.
+		return fmt.Errorf("couldn't create registry: %v", outputES)
 	}
 
 	var (


### PR DESCRIPTION
The `NewRegistry` method in `elastic-agent-libs` is inherently unsafe, especially in concurrent code: calling `NewRegistry` on a name that already exists causes a panic, but checking whether the name exists first is not atomic. The recently added `GetOrCreateRegistry` method is a safe alternative that checks the name's existence and initializes it atomically, and never panics. This PR removes the last remaining `NewRegistry` call in the apm-server repo.

## Related issues

This is a precautionary followup to https://github.com/elastic/fleet-server/issues/5170 and https://github.com/elastic/apm-server/pull/17872, where a different `NewRegistry` call site caused a panic on server reload.