### PR TITLE
build: stop producing rpm and deb apm-server-fips artifacts

### DIFF
--- a/packaging.mk
+++ b/packaging.mk
@@ -114,29 +114,17 @@ build/nfpm-%.yml: packaging/nfpm.yml
 DEB_ARCH := amd64 arm64
 DEBS := $(patsubst %, $(DISTDIR)/apm-server-$(APM_SERVER_VERSION)-%.deb, $(DEB_ARCH))
 DEBS += $(patsubst %, $(DISTDIR)/apm-server-$(APM_SERVER_VERSION)-SNAPSHOT-%.deb, $(DEB_ARCH))
-ifdef GENERATE_FIPS_ARTIFACTS
-DEBS += $(patsubst %, $(DISTDIR)/apm-server-fips-$(APM_SERVER_VERSION)-%.deb, $(DEB_ARCH))
-DEBS += $(patsubst %, $(DISTDIR)/apm-server-fips-$(APM_SERVER_VERSION)-SNAPSHOT-%.deb, $(DEB_ARCH))
-endif
 DEBS_AMD64 := $(filter %-amd64.deb, $(DEBS))
 DEBS_ARM64 := $(filter %-arm64.deb, $(DEBS))
 
 RPM_ARCH := x86_64 aarch64
 RPMS := $(patsubst %, $(DISTDIR)/apm-server-$(APM_SERVER_VERSION)-%.rpm, $(RPM_ARCH))
 RPMS += $(patsubst %, $(DISTDIR)/apm-server-$(APM_SERVER_VERSION)-SNAPSHOT-%.rpm, $(RPM_ARCH))
-ifdef GENERATE_FIPS_ARTIFACTS
-RPMS += $(patsubst %, $(DISTDIR)/apm-server-fips-$(APM_SERVER_VERSION)-%.rpm, $(RPM_ARCH))
-RPMS += $(patsubst %, $(DISTDIR)/apm-server-fips-$(APM_SERVER_VERSION)-SNAPSHOT-%.rpm, $(RPM_ARCH))
-endif
 RPMS_AMD64 := $(filter %-x86_64.rpm, $(RPMS))
 RPMS_ARM64 := $(filter %-aarch64.rpm, $(RPMS))
 
 $(DEBS_ARM64) $(RPMS_ARM64): $(COMMON_PACKAGE_FILES) build/apm-server-linux-arm64 build/nfpm-arm64.yml
 $(DEBS_AMD64) $(RPMS_AMD64): $(COMMON_PACKAGE_FILES) build/apm-server-linux-amd64 build/nfpm-amd64.yml
-ifdef GENERATE_FIPS_ARTIFACTS
-$(DEBS_ARM64) $(RPMS_ARM64): build/apm-server-fips-linux-arm64
-$(DEBS_AMD64) $(RPMS_AMD64): build/apm-server-fips-linux-amd64
-endif
 
 %.deb %.rpm:
 	@mkdir -p $(DISTDIR)


### PR DESCRIPTION
## Motivation/summary

we don't want to produce apm-server-fips rpm and deb packages

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
