### PR TITLE
fix: drop deb and rpm files from fips package task

### DIFF
--- a/packaging.mk
+++ b/packaging.mk
@@ -203,11 +203,7 @@ PACKAGE_SUFFIXES := \
 
 PACKAGE_FIPS_SUFFIXES := \
 	linux-x86_64.tar.gz \
-	linux-arm64.tar.gz \
-	amd64.deb \
-	arm64.deb \
-	x86_64.rpm \
-	aarch64.rpm
+	linux-arm64.tar.gz
 
 build/dependencies-$(APM_SERVER_VERSION)-SNAPSHOT.csv: build/dependencies-$(APM_SERVER_VERSION).csv
 	cp $< $@


### PR DESCRIPTION
## Motivation/summary

the package task was still trying to generate deb and rpm fips artifacts

drop leftover package targets

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

fix bug introduced by https://github.com/elastic/apm-server/pull/18199
