### PR TITLE
add rum test for geoip tags

### DIFF
--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -12,27 +12,6 @@
         "agent.version": [
             "5.5.0"
         ],
-        "client.geo.city_name": [
-            "dynamic"
-        ],
-        "client.geo.continent_name": [
-            "Oceania"
-        ],
-        "client.geo.country_iso_code": [
-            "AU"
-        ],
-        "client.geo.country_name": [
-            "Australia"
-        ],
-        "client.geo.location": [
-            "dynamic"
-        ],
-        "client.geo.region_iso_code": [
-            "dynamic"
-        ],
-        "client.geo.region_name": [
-            "dynamic"
-        ],
         "client.ip": [
             "220.244.41.16"
         ],
@@ -130,27 +109,6 @@
         ],
         "agent.version": [
             "5.5.0"
-        ],
-        "client.geo.city_name": [
-            "dynamic"
-        ],
-        "client.geo.continent_name": [
-            "Oceania"
-        ],
-        "client.geo.country_iso_code": [
-            "AU"
-        ],
-        "client.geo.country_name": [
-            "Australia"
-        ],
-        "client.geo.location": [
-            "dynamic"
-        ],
-        "client.geo.region_iso_code": [
-            "dynamic"
-        ],
-        "client.geo.region_name": [
-            "dynamic"
         ],
         "client.ip": [
             "220.244.41.16"

--- a/systemtest/rum_test.go
+++ b/systemtest/rum_test.go
@@ -89,7 +89,6 @@ func TestRUMGeoIpTags(t *testing.T) {
 
 	// Error if geoIp enrichment failed.
 	for _, hit := range result.Hits.Hits {
-		fmt.Println(hit)
 		if v, ok := hit.Source["tags"]; ok {
 			t.Errorf("unexpected tags field in document: %v", v)
 		}


### PR DESCRIPTION
Closes https://github.com/elastic/apm-server/issues/17603

This system test should fail if there are any `tags` in the indexed doc. This test ensure that if, for some reason, we cannot connect or download the `geoIP` database, the system tests will fail.

The systems test leverage docker volumes to link the geoip database, see [docker-compose](https://github.com/elastic/apm-server/blob/13e35d76bcf2c01a1491a933937f1e3ee4d16d3a/docker-compose.yml#L40). Therefore, properly testing this PR requires some manual steps.

- Either delete or comment the docker volume line linked above.
- Ensure you are pulling a clean ES image. I typically like to keep my local clean, so I'll remove all containers and images:
```shell
# Remove all running container instances
> docker rm -f $(docker ps -a -q)

# Remove all built images
> docker rmi -f $(docker images -a -q)
```
- Running `make system-test` should fail with the following error:
```shell
> make system-test

rum_test.go:94: unexpected tags field in document: [_geoip_database_unavailable_GeoLite2-City.mmdb]
```
- Repeat, but with the `ingest-geoip` volume enabled in `docker-compose.yml`, then the system test will pass.