### PR TITLE
update system test for geoip database

### DIFF
--- a/systemtest/apmservertest/server.go
+++ b/systemtest/apmservertest/server.go
@@ -155,7 +155,7 @@ func NewUnstartedServerTB(tb testing.TB, args ...string) *Server {
 				tb.Error(err)
 			}
 			close(errc)
-		case <-time.After(10 * time.Second):
+		case <-time.After(30 * time.Second):
 			// Channel receive on errc never happened. Start up a
 			// goroutine to receive on errc and then clean up the
 			// associated resources.

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -12,27 +12,6 @@
         "agent.version": [
             "5.5.0"
         ],
-        "client.geo.city_name": [
-            "dynamic"
-        ],
-        "client.geo.continent_name": [
-            "Oceania"
-        ],
-        "client.geo.country_iso_code": [
-            "AU"
-        ],
-        "client.geo.country_name": [
-            "Australia"
-        ],
-        "client.geo.location": [
-            "dynamic"
-        ],
-        "client.geo.region_iso_code": [
-            "dynamic"
-        ],
-        "client.geo.region_name": [
-            "dynamic"
-        ],
         "client.ip": [
             "220.244.41.16"
         ],
@@ -130,27 +109,6 @@
         ],
         "agent.version": [
             "5.5.0"
-        ],
-        "client.geo.city_name": [
-            "dynamic"
-        ],
-        "client.geo.continent_name": [
-            "Oceania"
-        ],
-        "client.geo.country_iso_code": [
-            "AU"
-        ],
-        "client.geo.country_name": [
-            "Australia"
-        ],
-        "client.geo.location": [
-            "dynamic"
-        ],
-        "client.geo.region_iso_code": [
-            "dynamic"
-        ],
-        "client.geo.region_name": [
-            "dynamic"
         ],
         "client.ip": [
             "220.244.41.16"

--- a/systemtest/containers.go
+++ b/systemtest/containers.go
@@ -87,6 +87,7 @@ func StartStackContainers() error {
 }
 
 func ToggleGeoIpMount(ctx context.Context, enable bool) error {
+
 	src := filepath.Join(
 		systemtestDir,
 		"..",
@@ -102,6 +103,7 @@ func ToggleGeoIpMount(ctx context.Context, enable bool) error {
 		return err
 	}
 	defer cli.Close()
+	cli.NegotiateAPIVersion(ctx)
 
 	c, err := stackContainerInfo(ctx, cli, "elasticsearch")
 	if err != nil {

--- a/systemtest/containers.go
+++ b/systemtest/containers.go
@@ -104,7 +104,6 @@ func ToggleGeoIpMount(ctx context.Context, enable bool) error {
 	defer cli.Close()
 
 	c, err := stackContainerInfo(ctx, cli, "elasticsearch")
-	fmt.Println("Container ID:", c.ID)
 	if err != nil {
 		return err
 	}
@@ -192,7 +191,6 @@ func ToggleGeoIpMount(ctx context.Context, enable bool) error {
 	}
 
 	kb, err := stackContainerInfo(ctx, cli, "kibana")
-	fmt.Println("Kibana Container ID:", kb.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes https://github.com/elastic/apm-server/issues/17603

Update system tests to ensure the [GeoIp Pipeline](https://github.com/elastic/elasticsearch/blob/4bcc35309c2b6d7577f42202899a69b2fd11280a/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/apm%40pipeline.yaml#L13) defined in `apm-data` plugin returns the proper result if the GeoIp database is found (not found).

GeoIp is mostly used with RUM, therefore the tests are added in `systemtest/rum_test.go`. We have a few different options to manipulate the database availability:

## 1. Download and remove GeoIp database

Initial look in https://github.com/elastic/apm-server/pull/18217. There are serval issues with this:

- On my local, this takes about `20` seconds to download, which will be a problem in CI.
- Since the test order is non-deterministic, we will have to download/remove it multiple times - depending on the test.
- The original reason for introducing the mount volume was to get rid of networking issues in CI, see [PR](https://github.com/elastic/apm-server/pull/8065).

## 2. Programmatically change the mounted GeoIp database file name:

- Due to this being a `bind` mount, changing the db filename within the container will also mutate the host filename in the `testdata` dir.
- Changing the file name dynamically on the host won't work either, since docker does not have hot-reloading.

## 3. Solution: Programmatically toggle the mount volume

Therefore, the most robust solution would be to toggle the mount volume by dynamically stopping and starting the container with the required mounts.

- Restarting a container is much faster than redownloading the db.
- The system tests becomes more expressive.
