### PR TITLE
Add applies_to statements

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -2,6 +2,12 @@
 navigation_title: "Breaking changes"
 mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-breaking.html
+applies_to:
+  stack: ga
+  serverless: unavailable
+products:
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM breaking changes

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -4,7 +4,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-breaking.html
 applies_to:
   stack: ga
-  serverless: unavailable
 products:
   - id: observability
   - id: apm

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -4,9 +4,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-breaking.html
 applies_to:
   stack: ga
-products:
-  - id: observability
-  - id: apm
 ---
 
 # Elastic APM breaking changes

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -1,5 +1,11 @@
 ---
 navigation_title: "Deprecations"
+applies_to:
+  stack: ga
+  serverless: unavailable
+products:
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM deprecations

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -2,9 +2,6 @@
 navigation_title: "Deprecations"
 applies_to:
   stack: ga
-products:
-  - id: observability
-  - id: apm
 ---
 
 # Elastic APM deprecations

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -2,7 +2,6 @@
 navigation_title: "Deprecations"
 applies_to:
   stack: ga
-  serverless: unavailable
 products:
   - id: observability
   - id: apm

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,9 +5,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/observability/master/release-notes-head.html
 applies_to:
   stack: ga
-products:
-  - id: observability
-  - id: apm
 ---
 
 # Elastic APM release notes

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,7 +5,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/observability/master/release-notes-head.html
 applies_to:
   stack: ga
-  serverless: unavailable
 products:
   - id: observability
   - id: apm

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -3,6 +3,12 @@ navigation_title: "Elastic APM"
 mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-release-notes.html
   - https://www.elastic.co/guide/en/observability/master/release-notes-head.html
+applies_to:
+  stack: ga
+  serverless: unavailable
+products:
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM release notes

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -4,9 +4,6 @@ mapped_pages:
 navigation_title: "Known issues"
 applies_to:
   stack: ga
-products:
-  - id: observability
-  - id: apm
 ---
 
 # Elastic APM known issues

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -4,7 +4,6 @@ mapped_pages:
 navigation_title: "Known issues"
 applies_to:
   stack: ga
-  serverless: unavailable
 products:
   - id: observability
   - id: apm

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,8 +1,13 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-known-issues.html
-
 navigation_title: "Known issues"
+applies_to:
+  stack: ga
+  serverless: unavailable
+products:
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM known issues


### PR DESCRIPTION
Adds ` applies_to` metadata for cumulative docs. See https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies

Contributes to https://github.com/elastic/docs-content-internal/issues/253