### PR TITLE
test: always build multi-arch image for elastic-agent-cloud

### DIFF
--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -185,10 +185,7 @@ docker_image.auto.tfvars:
 # with the local APM Server binary injected. The image will be based
 # off the stack version defined in ${REPO_ROOT}/docker-compose.yml,
 # unless overridden.
-.PHONY: build_elastic_agent_docker_image
-elastic_agent_docker_image: build_elastic_agent_docker_image
-	docker push "${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}"
-build_elastic_agent_docker_image:
-	@env BASE_IMAGE=${ELASTIC_AGENT_DOCKER_IMAGE}:${ELASTIC_AGENT_IMAGE_TAG} GOARCH=amd64 \
+elastic_agent_docker_image:
+	@env BASE_IMAGE=${ELASTIC_AGENT_DOCKER_IMAGE}:${ELASTIC_AGENT_IMAGE_TAG} \
 		bash ${REPO_ROOT}/testing/docker/elastic-agent/build.sh \
 		     -t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}

--- a/testing/cloud/Makefile
+++ b/testing/cloud/Makefile
@@ -51,10 +51,7 @@ destroy:
 # with the local APM Server binary injected. The image will be based
 # off the stack version defined in ${REPO_ROOT}/docker-compose.yml,
 # unless overridden.
-.PHONY: build_elastic_agent_docker_image
-elastic_agent_docker_image: build_elastic_agent_docker_image
-	docker push "${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}"
-build_elastic_agent_docker_image:
-	@env BASE_IMAGE=${ELASTIC_AGENT_DOCKER_IMAGE}:${ELASTIC_AGENT_IMAGE_TAG} GOARCH=amd64 \
+elastic_agent_docker_image:
+	@env BASE_IMAGE=${ELASTIC_AGENT_DOCKER_IMAGE}:${ELASTIC_AGENT_IMAGE_TAG} \
 		bash ${REPO_ROOT}/testing/docker/elastic-agent/build.sh \
 		     -t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}

--- a/testing/docker/elastic-agent/Dockerfile
+++ b/testing/docker/elastic-agent/Dockerfile
@@ -1,13 +1,7 @@
 ARG ELASTIC_AGENT_IMAGE # e.g. docker.elastic.co/cloud-release/elastic-agent-cloud:8.5.0-7dbc10f8-SNAPSHOT
 
-FROM --platform=linux/amd64 ${ELASTIC_AGENT_IMAGE} as elastic_agent_amd64
+FROM --platform=$TARGETPLATFORM ${ELASTIC_AGENT_IMAGE}
 ARG STACK_VERSION # e.g. 8.5.0-SNAPSHOT
 ARG VCS_REF_SHORT # e.g. abc123
-ONBUILD COPY --chmod=0755 --chown=elastic-agent apm-server-linux-amd64 ./data/elastic-agent-${VCS_REF_SHORT}/components/apm-server
-
-FROM --platform=linux/arm64 ${ELASTIC_AGENT_IMAGE} as elastic_agent_arm64
-ARG STACK_VERSION # e.g. 8.5.0-SNAPSHOT
-ARG VCS_REF_SHORT # e.g. abc123
-ONBUILD COPY --chmod=0755 --chown=elastic-agent apm-server-linux-arm64 ./data/elastic-agent-${VCS_REF_SHORT}/components/apm-server
-
-FROM elastic_agent_${TARGETARCH}
+ARG TARGETARCH
+ONBUILD COPY --chmod=0755 --chown=elastic-agent apm-server-linux-${TARGETARCH} ./data/elastic-agent-${VCS_REF_SHORT}/components/apm-server

--- a/testing/docker/elastic-agent/build.sh
+++ b/testing/docker/elastic-agent/build.sh
@@ -10,7 +10,6 @@ REPO_ROOT=$(cd $(dirname $(readlink -f "$0"))/../../.. && pwd)
 
 DEFAULT_IMAGE_TAG=$(grep docker.elastic.co/kibana ${REPO_ROOT}/docker-compose.yml | cut -d: -f3)
 BASE_IMAGE="${BASE_IMAGE:-docker.elastic.co/beats/elastic-agent:$DEFAULT_IMAGE_TAG}"
-GOARCH="${GOARCH:-$(go env GOARCH)}"
 
 export DOCKER_BUILDKIT=1
 docker pull $BASE_IMAGE
@@ -18,12 +17,14 @@ docker pull $BASE_IMAGE
 STACK_VERSION=$(docker inspect -f '{{index .Config.Labels "org.label-schema.version"}}' $BASE_IMAGE)
 VCS_REF=$(docker inspect -f '{{index .Config.Labels "org.label-schema.vcs-ref"}}' $BASE_IMAGE)
 
-make -C $REPO_ROOT build/apm-server-linux-$GOARCH
+make -C $REPO_ROOT build/apm-server-linux-amd64
+make -C $REPO_ROOT build/apm-server-linux-arm64
 
-docker build \
+docker buildx build \
 	-f $REPO_ROOT/testing/docker/elastic-agent/Dockerfile \
 	--build-arg ELASTIC_AGENT_IMAGE=$BASE_IMAGE \
 	--build-arg STACK_VERSION=$STACK_VERSION \
 	--build-arg VCS_REF_SHORT=${VCS_REF:0:6} \
-	--platform linux/$GOARCH \
+	--platform linux/amd64,linux/arm64 \
+	--push \
 	$* $REPO_ROOT/build


### PR DESCRIPTION
## Motivation/summary

To override the cloud image the elastic-agent image is fetched and modified by replacing the apm-server binary with a local copy. The GOARCH is hardcoded to amd64 so it's not possible to use a local apm-server in an arm64 deployment in cloud.

Update make task to always build a multi-platform image and target linux/amd64 and linux/arm64.

Update Dockerfile to copy the correct binary based on TARGETARCH

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- run `make docker-override-committed-version`
- run `make apply`
- observe elastic cloud deployment working for both arm64 and amd64 deployments

## Related issues

Closes https://github.com/elastic/apm-server/issues/17927
