### PR TITLE
github-actions: support backport labels after being merged

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -2,7 +2,7 @@ name: Backport to active branches
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
     branches:
       - main
 
@@ -13,9 +13,13 @@ permissions:
 jobs:
   backport:
     # Only run if the PR was merged (not just closed) and has one of the backport labels
+    # or has been added afterwards.
     if: |
-      github.event.pull_request.merged == true && 
-      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')) ||
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport-active-'))
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Support backports after a PR has been merged and labelled with `backport-active-*`.

## Motivation/summary

Fixes a corner case when the PRs have been labeled after being merged with the supported list of active branches.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
