### PR TITLE
github-actions: treat skipped jobs as success when reporting

### DIFF
--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -85,7 +85,6 @@ jobs:
         uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
           jobs: ${{ toJSON(needs) }}
-          skipped-as-success: 'true'
       - if: ${{ steps.check.outputs.isSuccess == 'false' }}
         uses: elastic/oblt-actions/slack/send@v1
         with:

--- a/.github/workflows/check-docker-compose.yml
+++ b/.github/workflows/check-docker-compose.yml
@@ -47,7 +47,6 @@ jobs:
         uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
           jobs: ${{ toJSON(needs) }}
-          skipped-as-success: 'true'
       - run: ${{ steps.check.outputs.isSuccess }}
       - if: failure()
         uses: elastic/oblt-actions/slack/notify-result@v1


### PR DESCRIPTION
## Motivation/summary

Support the case of sophisticated GitHub worfklows that might or might not run jobs, but the final outcome should treat the skipped or success jobs as success.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Uses https://github.com/elastic/oblt-actions/pull/339

Closes https://github.com/elastic/apm-server/issues/18400
