### PR TITLE
ci: remove STIG check pipeline

### DIFF
--- a/.buildkite/package.yml
+++ b/.buildkite/package.yml
@@ -60,12 +60,3 @@ steps:
     depends_on:
       - step: "package"
         allow_failure: false
-
-  - label: "Trigger stig-status pipeline docker.elastic.co/apm/apm-server-fips:${BUILDKITE_BRANCH}-SNAPSHOT"
-    trigger: stig-status
-    if: build.branch != "main"
-    build:
-      env:
-        CONTAINER_IMAGE: "docker.elastic.co/apm/apm-server-fips:${BUILDKITE_BRANCH}-SNAPSHOT"
-    depends_on:
-      - step: "dra"


### PR DESCRIPTION
## Motivation/summary

after discussion with the release team this will be part of the release pipeline so there's no need to run it in our repo

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/18155