### PR TITLE
bk: support DRA for branches that are not feature/*

### DIFF
--- a/.buildkite/scripts/utils.sh
+++ b/.buildkite/scripts/utils.sh
@@ -59,6 +59,11 @@ dra_process_other_branches() {
       fi
     fi
   fi
+  if [ "$BUILDKITE_PULL_REQUEST" == "false" ]; then
+    buildkite-agent annotate "Pull Requests are not supported by DRA. Look for the supported branches in ${BRANCHES_URL}" --style 'info' --context 'ctx-info-pr'
+    DRA_COMMAND=list
+    DRA_BRANCH=main
+  fi
   export DRA_BRANCH DRA_COMMAND VERSION
 }
 


### PR DESCRIPTION
## Motivation/summary

DRA should run for any branch and be clever enough to know what DRA branch to be used, that's ok for PRs, but it's not the case for feature branches that start with a different name than `features/`

Fixes

<img width="995" height="658" alt="image" src="https://github.com/user-attachments/assets/41c520fd-edf9-48c4-8266-8131c76b2e88" />


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
