### PR TITLE
ci: backport dependabot PRs to active 9.x branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       - dependency-name: "github.com/elastic/beats/v7"
     schedule:
       interval: "daily"
+    labels:
+      - "backport-active-9"
     groups:
       otel:
         patterns:
@@ -36,6 +38,8 @@ updates:
     directory: "/packaging/docker/"
     schedule:
       interval: "weekly"
+    labels:
+      - "backport-active-9"
     groups:
       docker:
         patterns:


### PR DESCRIPTION
## Motivation/summary

Add the backport‑active‑9 label to certain Dependabot pull requests so that non‑LTS branches (9.x) receive backport labels for Go dependency and Docker image updates. Previously, only the 8.19 and main branches were covered by Dependabot. This change extend coverage to include the 9.x series.
Use a label instead of target to avoid having to keep the branches up to date.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/18279
