### PR TITLE
lint(fips): add make task to validate fips dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ check-git-diff:
 
 .PHONY: check-fips-deps
 check-fips-deps:
-	! go list -m $(MODULE_DEPS) | grep -E -q 'github.com/jcmturner/aescts/v2|github.com/jcmturner/gofork|github.com/jcmturner/gokrb5/v8|github.com/xdg-go/pbkdf2|golang.org/x/crypto'
+	! go list -m $(MODULE_DEPS_FIPS) | grep -E -q 'github.com/jcmturner/aescts/v2|github.com/jcmturner/gofork|github.com/jcmturner/gokrb5/v8|github.com/xdg-go/pbkdf2|golang.org/x/crypto'
 
 BENCH_BENCHTIME?=100ms
 BENCH_COUNT?=1


### PR DESCRIPTION
## Motivation/summary

ensure specific dependencies are not included in the fips binary

we have to exclude certain dependencies from the fips binary due to fips requirements.
Add a lint check that also runs in CI to avoid regressions

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

`make check`

## Related issues

Closes https://github.com/elastic/apm-server/issues/18605
