### PR TITLE
test(TestLibbeatMetrics): wait until batches count is expected value

### DIFF
--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -155,10 +155,11 @@ func TestLibbeatMetrics(t *testing.T) {
 		assert.NoError(t, appender.Close(context.Background()))
 	}()
 
-	require.NoError(t, appender.Add(context.Background(), "index", strings.NewReader("{}")))
-	require.NoError(t, appender.Add(context.Background(), "index", strings.NewReader("{}")))
-	require.NoError(t, appender.Add(context.Background(), "index", strings.NewReader("{}")))
-	require.NoError(t, appender.Add(context.Background(), "index", strings.NewReader("{}")))
+	const totalRequests = 4
+
+	for range totalRequests {
+		require.NoError(t, appender.Add(context.Background(), "index", strings.NewReader("{}")))
+	}
 
 	statsRegistry := beat.Monitoring.StatsRegistry()
 	libbeatRegistry := statsRegistry.GetRegistry("libbeat")
@@ -167,13 +168,13 @@ func TestLibbeatMetrics(t *testing.T) {
 		"output": map[string]any{
 			"type": "elasticsearch",
 			"events": map[string]any{
-				"active": int64(4),
-				"total":  int64(4),
+				"active": int64(totalRequests),
+				"total":  int64(totalRequests),
 			},
 		},
 		"pipeline": map[string]any{
 			"events": map[string]any{
-				"total": int64(4),
+				"total": int64(totalRequests),
 			},
 		},
 	}, snapshot)
@@ -182,7 +183,7 @@ func TestLibbeatMetrics(t *testing.T) {
 		return appender.IndexersActive() > 1
 	}, 10*time.Second, 50*time.Millisecond)
 
-	for i := 0; i < 4; i++ {
+	for range totalRequests {
 		unblockRequest := make(chan struct{})
 		requestsChan <- unblockRequest
 		unblockRequest <- struct{}{}
@@ -192,7 +193,7 @@ func TestLibbeatMetrics(t *testing.T) {
 		snapshot = monitoring.CollectStructSnapshot(libbeatRegistry, monitoring.Full, false)
 		output := snapshot["output"].(map[string]any)
 		events := output["events"].(map[string]any)
-		return events["active"] == int64(0) && events["batches"] == int64(4)
+		return events["active"] == int64(0) && events["batches"] == int64(totalRequests)
 	}, 10*time.Second, 100*time.Millisecond)
 	assert.Equal(t, map[string]any{
 		"output": map[string]any{
@@ -202,8 +203,8 @@ func TestLibbeatMetrics(t *testing.T) {
 				"failed":  int64(2),
 				"toomany": int64(1),
 				"active":  int64(0),
-				"total":   int64(4),
-				"batches": int64(4),
+				"total":   int64(totalRequests),
+				"batches": int64(totalRequests),
 			},
 			"write": map[string]any{
 				"bytes": int64(132),
@@ -211,7 +212,7 @@ func TestLibbeatMetrics(t *testing.T) {
 		},
 		"pipeline": map[string]any{
 			"events": map[string]any{
-				"total": int64(4),
+				"total": int64(totalRequests),
 			},
 		},
 	}, snapshot)
@@ -221,7 +222,7 @@ func TestLibbeatMetrics(t *testing.T) {
 		"elasticsearch": map[string]any{
 			"bulk_requests": map[string]any{
 				"available": int64(10),
-				"completed": int64(4),
+				"completed": int64(totalRequests),
 			},
 			"indexers": map[string]any{
 				"active":    int64(2),


### PR DESCRIPTION
## Motivation/summary

When there are no active indexers but only a subset of bulk requests (e.g., two) have been counted, the bulk‑request metrics become inconsistent and cause test failures.

This change waits until the number of active indexers drops to 0 and the bulk‑request counter reaches 4, guaranteeing that all batches and their statuses are fully accounted for.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- `go test -race -v -count=1000 -failfast -run=TestLibbeatMetrics ./...`

## Related issues

Related to https://github.com/elastic/apm-server/issues/18558
