### PR TITLE
lint(fips): remove unused ms_tls13kdf tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ apm-server-fips apm-server-fips-msft: CGO_ENABLED=1
 apm-server apm-server-oss: CGO_ENABLED=0
 
 apm-server-fips: GOTAGS=requirefips
-apm-server-fips-msft: GOTAGS=requirefips,ms_tls13kdf,relaxfips
+apm-server-fips-msft: GOTAGS=requirefips,relaxfips
 
 apm-server-oss: SUFFIX=-oss
 apm-server-fips apm-server-fips-msft: SUFFIX=-fips


### PR DESCRIPTION
## Motivation/summary

ms_tls13kdf was added to backport the TLS 1.3 changes to Go 1.24 in Microsoft’s fork, but it isn’t needed in Go 1.25.

This commit drops the unused tag.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/18653
