### PR TITLE
test(TestWrapServerAPMInstrumentationTimeout): wait for expected doc and don't skip assertions

### DIFF
--- a/internal/beater/server_test.go
+++ b/internal/beater/server_test.go
@@ -626,7 +626,6 @@ func TestWrapServerAPMInstrumentationTimeout(t *testing.T) {
 				}
 			}
 			require.NoError(t, json.Unmarshal(doc, &out))
-			t.Log(string(doc))
 			if out.Transaction.ID != "" && out.Transaction.Name == "POST /intake/v2/events" {
 				assert.Equal(t, "HTTP 5xx", out.Transaction.Result)
 				assert.Equal(t, http.StatusServiceUnavailable, out.HTTP.Response.StatusCode)


### PR DESCRIPTION
## Motivation/summary

A request to the intake endpoint could trigger multiple bulk requests when instrumentation is enabled. The original select statement only waited for the first document and ran assertions conditionally, which meant that if the self‑instrumentation bulk request arrived first, the assertions were skipped.

This left the server logs empty and caused a panic on the subsequent assertion because it tried to read a non‑existent log line.

Finally the statuscode assertions will always fail because the json name was incorrect causing the field to always be 0

The fix changes the select to loop until the expected document arrives, guaranteeing that the assertions are executed. Additionally, the log‑length check now fails explicitly when the log is empty, preventing the later panic.

example failure: https://github.com/elastic/apm-server/actions/runs/17980151794/job/51143750459

(look at raw logs to see failure)

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- `go test -race -count=1000 -failfast -run=TestWrapServerAPMInstrumentationTimeout ./...`
- adding some logs to show that assertions were not run previously in some cases

## Related issues

Related to https://github.com/elastic/apm-server/issues/18558
