### PR TITLE
test: close apmserver before waiting for geoip download

### DIFF
--- a/systemtest/main_test.go
+++ b/systemtest/main_test.go
@@ -77,11 +77,11 @@ func GeoIpLazyDownload() error {
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 
-	if err := srv.Close(); err != nil {
+	if err := waitGeoIPDownload(); err != nil {
 		return err
 	}
 
-	if err := waitGeoIPDownload(); err != nil {
+	if err := srv.Close(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Motivation/summary

close apmserver while waiting for geoip db to be downloaded

resolve flaky aggregation systemtest caused by leaking server pushing aggregation metrics

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- `cd systemtest && go test -race -count=100 -failfast -v -run=TestServiceSummaryMetricsAggregation -timeout=60m ./...`

## Related issues

Related to https://github.com/elastic/apm-server/issues/18558
