### PR TITLE
test: wrap ratelimit log test in synctest bubble

### DIFF
--- a/internal/logs/ratelimit_test.go
+++ b/internal/logs/ratelimit_test.go
@@ -19,34 +19,31 @@ package logs_test
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/elastic/apm-server/internal/logs"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestWithRateLimit(t *testing.T) {
-	core, observed := observer.New(zapcore.DebugLevel)
-	logger := logptest.NewTestingLogger(t, "bo", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
-		return zapcore.NewTee(in, core)
-	}))
+	synctest.Test(t, func(t *testing.T) {
+		logger, observed := logptest.NewTestingLoggerWithObserver(t, "bo")
 
-	const interval = 100 * time.Millisecond
-	limitedLogger := logger.WithOptions(logs.WithRateLimit(interval))
+		const interval = 100 * time.Millisecond
+		limitedLogger := logger.WithOptions(logs.WithRateLimit(interval))
 
-	// Log twice in quick succession; the 2nd call will be ignored due to rate-limiting.
-	limitedLogger.Info("hello")
-	limitedLogger.Info("hello")
-	assert.Equal(t, 1, observed.Len())
+		// Log twice in quick succession; the 2nd call will be ignored due to rate-limiting.
+		limitedLogger.Info("hello")
+		limitedLogger.Info("hello")
+		assert.Equal(t, 1, observed.Len())
 
-	// Sleep until the configured interval has elapsed, which should allow another
-	// record to be logged.
-	time.Sleep(interval)
-	limitedLogger.Info("hello")
-	assert.Equal(t, 2, observed.Len())
+		// Sleep until the configured interval has elapsed, which should allow another
+		// record to be logged.
+		time.Sleep(interval * 100)
+		limitedLogger.Info("hello")
+		assert.Equal(t, 2, observed.Len())
+	})
 }


### PR DESCRIPTION
## Motivation/summary

wrap the ratelimit log test in a time bubble to prevent some flaky test failure due to relying on time.Sleep.

test time went from 0.3s to 0s

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

I couldn't reproduce this locally, I guess the window for test failure is small because it's sleeping for the exact ratelimit amount.

failure was observed in CI: https://github.com/elastic/apm-server/actions/runs/18134496296/job/51609574362

## Related issues

Related to https://github.com/elastic/apm-server/issues/18558
