### PR TITLE
ci: build apm-server before running systemtests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,6 @@ jobs:
         with:
           go-version-file: systemtest/go.mod
           cache: false
-      - run: |
-            docker compose up -d &
-            make apm-server &
-            wait
       - uses: actions/cache@v4
         with:
           path: |
@@ -129,6 +125,10 @@ jobs:
           key: systemtest-go-${{ hashFiles('systemtest/go.mod', 'go.mod') }}
           restore-keys: |
             systemtest-go-
+      - run: |
+            docker compose up -d &
+            make apm-server &
+            wait
       - env:
           GOTESTFLAGS: "-v"
           GH_TOKEN: ${{ github.token }}
@@ -142,10 +142,6 @@ jobs:
         with:
           go-version-file: systemtest/go.mod
           cache: false
-      - run: |
-            docker compose up -d &
-            make apm-server &
-            wait
       - uses: actions/cache@v4
         with:
           path: |
@@ -153,6 +149,10 @@ jobs:
           key: systemtest-go-${{ hashFiles('systemtest/go.mod', 'go.mod') }}
           restore-keys: |
             systemtest-go-
+      - run: |
+            docker compose up -d &
+            make apm-server &
+            wait
       - env:
           GOTESTFLAGS: "-v -tags=requirefips"
           GOFIPS140: "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,10 @@ jobs:
         with:
           go-version-file: systemtest/go.mod
           cache: false
-      - run: docker compose up -d
+      - run: |
+            docker compose up -d &
+            make apm-server &
+            wait
       - uses: actions/cache@v4
         with:
           path: |
@@ -139,7 +142,10 @@ jobs:
         with:
           go-version-file: systemtest/go.mod
           cache: false
-      - run: docker compose up -d
+      - run: |
+            docker compose up -d &
+            make apm-server &
+            wait
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
## Motivation/summary

Go tests build a separate binary for each package. Because we have both systemtest and apmservertest packages the systemtest job creates two binaries which causes the make build task to run twice. Tests in multiple packages run in parallel so the build cache is not shared effectively.

Since the target OS (GOOS) and architecture (GOARCH) stay constant throughout a run, we only need a single binary. Storing cached paths in a map is unnecessary.

Changes:

Update the CI job to compile the apm‑server binary before executing the systemtests, allowing the build cache to be reused across packages.

Run the binary build in parallel with Docker image pulls to shave off additional time.

Replace the apmserverBinary mutex with a sync.Once, reducing contention within the same package.

This also appears to reduce systemtest job time by ~1m.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- watch CI systemtest job

## Related issues

Closes https://github.com/elastic/apm-server/issues/17487
