### PR TITLE
Revert "smoke: Fix deprecated aws_region name"

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">=6.0"
+      version = "~>4.17"
     }
     time = {
       source  = "hashicorp/time"

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -136,7 +136,7 @@ data "aws_subnets" "public_subnets" {
   }
   filter {
     name   = "availability-zone"
-    values = ["${data.aws_region.current.region}a"]
+    values = ["${data.aws_region.current.name}a"]
   }
 }
 


### PR DESCRIPTION
Reverts elastic/apm-server#18550 since its causing benchmarks to fail.