### PR TITLE
ci(benchmarks): working-directory is not honoured when using download-kibana-dashboard@v1

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -269,8 +269,20 @@ jobs:
           to-date: "now"
           png-filename: ${{ env.PNG_REPORT_FILE }}
 
+      - name: Debug PNG files
+        working-directory: "${{ github.workspace }}"
+        run: |
+          if [ -f "${{ env.PNG_REPORT_FILE }}" ]; then
+            echo "PNG report file exists in the top-level location."
+          elif [ -f " ${{ env.WORKING_DIRECTORY }}/${{ env.PNG_REPORT_FILE }}" ]; then
+            echo "PNG report file exists in the working directory."
+          else
+            echo "PNG report file does not exist in either location."
+          fi
+
       - name: Upload PNG to AWS S3
         id: s3-upload-png
+        working-directory: "${{ github.workspace }}"
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |


### PR DESCRIPTION
## Motivation/summary


https://github.com/elastic/apm-server/issues/19302 refactored the common script but the `working-directory` is not honoured

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

The default values differ from the scheduler in the Benchmarks GH Workflow:

```
Running benchmarks...
Benchmark warmup time: 10m
Benchmark agents: 512
Benchmark event rate: 0/s
Benchmark count: 6
Benchmark duration: 2m
Benchmark run expression : Benchmark[^T]
```

vs


```
Running benchmarks...
Benchmark warmup time: 5m
Benchmark agents: 512
Benchmark event rate: 0/s
Benchmark count: 6
Benchmark duration: 2m
Benchmark run expression : Benchmark
```

And as a consequence, it timed out, see https://github.com/elastic/apm-server/actions/runs/18939194947 when I tried the first run.

Running the Benchmark workflow and setting the same values as the one for the scheduler:
- https://github.com/elastic/apm-server/actions/runs/18967165835

<img width="1289" height="677" alt="image" src="https://github.com/user-attachments/assets/3c1cd411-bcd3-4c79-b179-362cc06ac5b4" />


## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
