### PR TITLE
CI(smoke): OS tests pinned AWS provider

### DIFF
--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -136,7 +136,7 @@ data "aws_subnets" "public_subnets" {
   }
   filter {
     name   = "availability-zone"
-    values = ["${data.aws_region.current.name}a"]
+    values = ["${data.aws_region.current.region}a"]
   }
 }
 

--- a/testing/smoke/supported-os/main.tf
+++ b/testing/smoke/supported-os/main.tf
@@ -5,6 +5,11 @@ terraform {
       source  = "elastic/ec"
       version = "0.5.1"
     }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6"
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation/summary

Smoke tests for OS are failing in the infra provisioning phase.
Could not replicate 

## How to test these changes


Running smoke tests locally with 

```
cd testing/smoke/supported-os
./test.sh 9.1.8-SNAPSHOT
```
