### PR TITLE
Revert "CI(smoke): OS tests pinned AWS provider"

### DIFF
--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -136,7 +136,7 @@ data "aws_subnets" "public_subnets" {
   }
   filter {
     name   = "availability-zone"
-    values = ["${data.aws_region.current.region}a"]
+    values = ["${data.aws_region.current.name}a"]
   }
 }
 

--- a/testing/smoke/supported-os/main.tf
+++ b/testing/smoke/supported-os/main.tf
@@ -5,11 +5,6 @@ terraform {
       source  = "elastic/ec"
       version = "0.5.1"
     }
-
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6"
-    }
   }
 }
 


### PR DESCRIPTION
Reverts elastic/apm-server#19622 because it breaks benchmark