### PR TITLE
fix: add missing span kind to otel traces

### DIFF
--- a/internal/agentcfg/elasticsearch.go
+++ b/internal/agentcfg/elasticsearch.go
@@ -152,7 +152,7 @@ func (f *ElasticsearchFetcher) Run(ctx context.Context) error {
 	refresh := func() bool {
 		// refresh returns a bool that indicates whether Run should return
 		// immediately without error, e.g. due to invalid Elasticsearch config.
-		ctx, tx := f.tracer.Start(ctx, "ElasticsearchFetcher.refresh")
+		ctx, tx := f.tracer.Start(ctx, "ElasticsearchFetcher.refresh", trace.WithSpanKind(trace.SpanKindInternal))
 		defer tx.End()
 
 		if err := f.refreshCache(ctx); err != nil {
@@ -220,7 +220,7 @@ type cacheResult struct {
 }
 
 func (f *ElasticsearchFetcher) refreshCache(ctx context.Context) (err error) {
-	ctx, span := f.tracer.Start(ctx, "ElasticsearchFetcher.refreshCache")
+	ctx, span := f.tracer.Start(ctx, "ElasticsearchFetcher.refreshCache", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 
 	scrollID := ""

--- a/internal/beater/interceptors/tracing.go
+++ b/internal/beater/interceptors/tracing.go
@@ -35,7 +35,7 @@ func Tracing(tp trace.TracerProvider) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (any, error) {
-		ctx, span := tracer.Start(ctx, info.FullMethod)
+		ctx, span := tracer.Start(ctx, info.FullMethod, trace.WithSpanKind(trace.SpanKindServer))
 		defer span.End()
 
 		resp, err := handler(ctx, req)

--- a/internal/beater/waitready.go
+++ b/internal/beater/waitready.go
@@ -39,7 +39,7 @@ func waitReady(
 ) error {
 	tracer := tp.Tracer("github.com/elastic/apm-server/internal/beater")
 	logger.Info("blocking ingestion until all preconditions are satisfied")
-	ctx, span := tracer.Start(ctx, "wait_for_preconditions")
+	ctx, span := tracer.Start(ctx, "wait_for_preconditions", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 	var ticker *time.Ticker
 	for {

--- a/internal/sourcemap/metadata_fetcher.go
+++ b/internal/sourcemap/metadata_fetcher.go
@@ -137,7 +137,7 @@ func (s *MetadataESFetcher) startBackgroundSync(ctx context.Context) {
 }
 
 func (s *MetadataESFetcher) sync(ctx context.Context) error {
-	ctx, tx := s.tracer.Start(ctx, "MetadataESFetcher.sync")
+	ctx, tx := s.tracer.Start(ctx, "MetadataESFetcher.sync", trace.WithSpanKind(trace.SpanKindInternal))
 	defer tx.End()
 
 	sourcemaps := make(map[identifier]string)
@@ -208,7 +208,7 @@ func (s *MetadataESFetcher) clearScroll(ctx context.Context, scrollID string) {
 }
 
 func (s *MetadataESFetcher) update(ctx context.Context, sourcemaps map[identifier]string) {
-	ctx, span := s.tracer.Start(ctx, "MetadataESFetcher.update")
+	ctx, span := s.tracer.Start(ctx, "MetadataESFetcher.update", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 
 	s.mu.Lock()
@@ -270,7 +270,7 @@ func (s *MetadataESFetcher) update(ctx context.Context, sourcemaps map[identifie
 }
 
 func (s *MetadataESFetcher) initialSearch(ctx context.Context, updates map[identifier]string) (*esSearchSourcemapResponse, error) {
-	ctx, span := s.tracer.Start(ctx, "MetadataESFetcher.initialSearch")
+	ctx, span := s.tracer.Start(ctx, "MetadataESFetcher.initialSearch", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 
 	resp, err := s.runSearchQuery(ctx)
@@ -371,7 +371,7 @@ func parseResponse(body io.ReadCloser, logger *logp.Logger) (*esSearchSourcemapR
 }
 
 func (s *MetadataESFetcher) scrollsearch(ctx context.Context, scrollID string, updates map[identifier]string) (*esSearchSourcemapResponse, error) {
-	ctx, span := s.tracer.Start(ctx, "MetadataESFetcher.scrollSearch")
+	ctx, span := s.tracer.Start(ctx, "MetadataESFetcher.scrollSearch", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 
 	resp, err := s.runScrollSearchQuery(ctx, scrollID)


### PR DESCRIPTION
## Motivation/summary

ensure self instrumentation traces have a span kind

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/19441
