### PR TITLE
infra(testing): upgrade AWS provider to 6.x

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.17"
+      version = "~>6"
     }
     time = {
       source  = "hashicorp/time"
@@ -48,7 +48,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.0"
+  version = "6.5.1"
 
   name = "${var.user_name}-worker"
   cidr = var.vpc_cidr

--- a/testing/infra/terraform/modules/benchmark_executor/instance.tf
+++ b/testing/infra/terraform/modules/benchmark_executor/instance.tf
@@ -31,7 +31,7 @@ data "aws_security_group" "security_group" {
 
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "3.5.0"
+  version = "6.1.5"
 
   ami                         = data.aws_ami.worker_ami.id
   instance_type               = var.instance_type

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -136,7 +136,7 @@ data "aws_subnets" "public_subnets" {
   }
   filter {
     name   = "availability-zone"
-    values = ["${data.aws_region.current.name}a"]
+    values = ["${data.aws_region.current.region}a"]
   }
 }
 

--- a/testing/smoke/supported-os/main.tf
+++ b/testing/smoke/supported-os/main.tf
@@ -5,6 +5,11 @@ terraform {
       source  = "elastic/ec"
       version = "0.5.1"
     }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>6"
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation/summary

Upgrade the TF projects in `testing` and pin the AWS provider to latest 6.x release.

Related: found and fixed a bug in the EC2 module https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/pull/466

## Checklist

## How to test these changes

I was able to test both the benchmarks and smoke-test supported OS provisioning projects without issues.

## Related issues

