### PR TITLE
test(systemtest): only build apm-server once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,11 @@ jobs:
           key: systemtest-go-${{ hashFiles('systemtest/go.mod', 'go.mod') }}
           restore-keys: |
             systemtest-go-
-      - run: |
+      - env:
+          NOCP: "1"
+          GOOS: "linux"
+          GOARCH: "amd64"
+        run: |
             docker compose up -d &
             make apm-server &
             wait
@@ -149,7 +153,11 @@ jobs:
           key: systemtest-go-${{ hashFiles('systemtest/go.mod', 'go.mod') }}
           restore-keys: |
             systemtest-go-
-      - run: |
+      - env:
+          NOCP: "1"
+          GOOS: "linux"
+          GOARCH: "amd64"
+        run: |
             docker compose up -d &
             make apm-server &
             wait


### PR DESCRIPTION
## Motivation/summary

pass NOCP=1 to avoid duplicating apm-server binary to the work dir 

explicitly pass GOOS and GOARCH to match systemtest behaviour and avoid building duplicate binary with a different name

`make apm-server` doesn't set GOOS and GOARCH, causing the job to build a `apm-server--amd64` binary

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/19609
