### PR TITLE
ci: use ubuntu-slim and filter if branch does not exist yet

### DIFF
--- a/.github/workflows/bump-elastic-stack.yml
+++ b/.github/workflows/bump-elastic-stack.yml
@@ -11,13 +11,15 @@ permissions:
 
 jobs:
   filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     outputs:
       matrix: ${{ steps.generator.outputs.matrix }}
     steps:
       - id: generator
         uses: elastic/oblt-actions/elastic/active-branches@v1
+        with:
+          filter-branches: true
 
   bump-elastic-stack:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-docker-compose.yml
+++ b/.github/workflows/check-docker-compose.yml
@@ -11,13 +11,15 @@ permissions:
 
 jobs:
   filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     outputs:
       matrix: ${{ steps.generator.outputs.matrix }}
     steps:
       - id: generator
         uses: elastic/oblt-actions/elastic/active-branches@v1
+        with:
+          filter-branches: true
 
   check-docker-compose:
     needs:

--- a/.github/workflows/smoke-tests-os-sched.yml
+++ b/.github/workflows/smoke-tests-os-sched.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   prepare-smoke-tests-os:
     name: Generate smoke tests list
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
@@ -31,6 +31,7 @@ jobs:
         uses: elastic/oblt-actions/elastic/active-branches@v1
         with:
           exclude-branches: '7.17'
+          filter-branches: true
 
   smoke-tests-os:
     name: Run smoke tests OS

--- a/.github/workflows/update-beats.yml
+++ b/.github/workflows/update-beats.yml
@@ -10,13 +10,15 @@ permissions:
 
 jobs:
   filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     outputs:
       matrix: ${{ steps.generator.outputs.matrix }}
     steps:
       - id: generator
         uses: elastic/oblt-actions/elastic/active-branches@v1
+        with:
+          filter-branches: true
   bump:
     needs:
       - filter


### PR DESCRIPTION
## Motivation/summary


`ubuntu-slim` runs faster and avoid using branches that don't exist yet.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

In the CI, I created a test branch and I ran https://github.com/elastic/apm-server/actions/runs/20273536554

<img width="1277" height="584" alt="image" src="https://github.com/user-attachments/assets/d7cd9353-0448-45c0-8c05-164572135089" />

vs

https://github.com/elastic/apm-server/actions/runs/20272416175

<img width="1383" height="540" alt="image" src="https://github.com/user-attachments/assets/b828c429-3d04-4793-b295-480956ce4ac2" />


## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
