### PR TITLE
Update future releases endpoint URL

### DIFF
--- a/integrationservertest/scripts/genpath/versions_bc.go
+++ b/integrationservertest/scripts/genpath/versions_bc.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// NOTE: This API may change in the future and not be accessible eventually.
-	futureReleasesAPI = "https://artifacts.elastic.co/releases/TfEVhiaBGqR64ie0g0r0uUwNAbEQMu1Z/future-releases/stack.json"
+	futureReleasesAPI = "https://ela.st/future-stack-releases"
 )
 
 type futureReleasesResp struct {


### PR DESCRIPTION
This pull request makes a small update to the URL used for fetching future stack releases in the `integrationservertest/scripts/genpath/versions_bc.go` file.