### PR TITLE
7.17 reached EoL

### DIFF
--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -58,32 +58,9 @@ jobs:
           GITHUB_BRANCH: '8.19'
           GITHUB_LABELS: 'backport-skip'
 
-  bump-7:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: '7.17'
-
-      - name: Get token
-        id: get_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          permission-contents: write
-          permission-pull-requests: write
-      - uses: elastic/oblt-actions/updatecli/run@v1
-        with:
-          command: --experimental apply --config .ci/updatecli/bump-golang.yml --values .ci/updatecli/values.d/scm.yml
-        env:
-          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
-          GITHUB_BRANCH: '7.17'
-          GITHUB_LABELS: 'backport-skip'
-
   notify:
     runs-on: ubuntu-latest
-    needs: [bump, bump-7, bump-819]
+    needs: [bump, bump-819]
     if: always()
     steps:
       - id: check

--- a/.github/workflows/smoke-tests-os-sched.yml
+++ b/.github/workflows/smoke-tests-os-sched.yml
@@ -22,7 +22,6 @@ jobs:
         name: Generate matrix
         uses: elastic/oblt-actions/elastic/active-branches@v1
         with:
-          exclude-branches: '7.17'
           filter-branches: true
 
   smoke-tests-os:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -45,9 +45,9 @@ spec:
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
+      cancel_intermediate_builds_branch_filter: "!main !8.* !9.*"
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
+      skip_intermediate_builds_branch_filter: "!main !8.* !9.*"
       teams:
         obs-ds-intake-services: {}
         observablt-robots: {}
@@ -55,8 +55,3 @@ spec:
           access_level: READ_ONLY
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
-      schedules:
-        Weekly 7.17:
-          branch: "7.17"
-          cronline: "@weekly"
-          message: Builds `7.17` DRA

--- a/integrationservertest/internal/ech/version_test.go
+++ b/integrationservertest/internal/ech/version_test.go
@@ -37,10 +37,10 @@ func newVersionsFromStrings(strs []string) (Versions, error) {
 }
 
 func TestVersions_Sort(t *testing.T) {
-	got, err := newVersionsFromStrings([]string{"9.0.0-SNAPSHOT", "8.14.5", "7.17.28", "9.0.0"})
+	got, err := newVersionsFromStrings([]string{"9.0.0-SNAPSHOT", "8.14.5", "7.17.29", "9.0.0"})
 	require.NoError(t, err)
 
-	expected, err := newVersionsFromStrings([]string{"7.17.28", "8.14.5", "9.0.0", "9.0.0-SNAPSHOT"})
+	expected, err := newVersionsFromStrings([]string{"7.17.29", "8.14.5", "9.0.0", "9.0.0-SNAPSHOT"})
 	require.NoError(t, err)
 
 	got.Sort()

--- a/release.mk
+++ b/release.mk
@@ -114,7 +114,6 @@ patch-release:
 	$(MAKE) create-branch NAME=$(BRANCH_PATCH) BASE=$(RELEASE_BRANCH)
 	$(MAKE) update-version VERSION=$(RELEASE_VERSION)
 	$(MAKE) update-version-makefile VERSION=$(PROJECT_MAJOR_VERSION)\.$(PROJECT_MINOR_VERSION)
-	$(MAKE) update-version-legacy VERSION=$(NEXT_RELEASE) PREVIOUS_VERSION=$(CURRENT_RELEASE)
 	$(MAKE) create-commit COMMIT_MESSAGE="$(RELEASE_BRANCH): update versions to $(RELEASE_VERSION)"
 	@echo "INFO: Push changes to $(PROJECT_OWNER)/apm-server and create the relevant Pull Requests"
 	$(MAKE) create-pull-request BRANCH=$(BRANCH_PATCH) TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(RELEASE_VERSION): update versions" BODY="Merge on request by the Release Manager." BACKPORT_LABEL=backport-skip
@@ -168,16 +167,6 @@ update-version:
 	fi
 	if [ -f "internal/version/version.go" ]; then \
 		$(SED) -E -e 's#(Version[[:blank:]]*)=[[:blank:]]*"[0-9]+\.[0-9]+\.[0-9]+#\1= "$(VERSION)#g' internal/version/version.go; \
-	fi
-
-## Update the version in the different files with the hardcoded version. Legacy stuff
-## @DEPRECATED: likely in the 7.17 branch
-.PHONY: update-version-legacy
-update-version-legacy: VERSION=$${VERSION} PREVIOUS_VERSION=$${PREVIOUS_VERSION}
-update-version-legacy:
-	@echo ">> update-version-legacy"
-	if [ -f "cmd/version.go" ]; then \
-		$(SED) -E -e 's#(defaultBeatVersion[[:blank:]]*)=[[:blank:]]*"[0-9]+\.[0-9]+\.[0-9]+#\1= "$(VERSION)#g' cmd/version.go; \
 	fi
 
 ## Update project version in the Makefile.


### PR DESCRIPTION
## Motivation/summary

7.17 reached EoL, therefore remove any scheduler or references to `7.17` in the automation. Besides, I bumped the version to use the latest available release for `7.17`: https://github.com/elastic/apm-server/releases/tag/v7.17.29

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
