### PR TITLE
ci: fix version validation on prepare-release

### DIFF
--- a/.github/workflows/prepare-release/action.yml
+++ b/.github/workflows/prepare-release/action.yml
@@ -52,23 +52,23 @@ runs:
     - name: validate version format (major only)
       if: ${{ inputs.type == 'major' && ! endsWith(inputs.version, '.0.0') }}
       run: |-
-        FAILURE_MESSAGE='version is not a major one but a patch (only support for <major>.0.0)'
+        FAILURE_MESSAGE='version is not a major one (only support for <major>.0.0)'
         echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
         echo "::error::${FAILURE_MESSAGE}" ; exit 1
       shell: 'bash'
 
     - name: validate version format (minor only)
-      if: ${{ inputs.type == 'minor' && ! endsWith(inputs.version, '0') }}
+      if: ${{ inputs.type == 'minor' && ! endsWith(inputs.version, '.0') }}
       run: |-
-        FAILURE_MESSAGE='version is not a minor one but a patch (only support for <major>.<minor>.0)'
+        FAILURE_MESSAGE='version is not a minor one (only support for <major>.<minor>.0)'
         echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
         echo "::error::${FAILURE_MESSAGE}" ; exit 1
       shell: 'bash'
 
     - name: validate version format (patch only)
-      if: ${{ inputs.type == 'patch' && endsWith(inputs.version, '0') }}
+      if: ${{ inputs.type == 'patch' && endsWith(inputs.version, '.0') }}
       run: |-
-        FAILURE_MESSAGE='version is not a patch one but a minor (only support for <major>.<minor>.[1-9]+[0-9]*)'
+        FAILURE_MESSAGE='version is not a patch one (only support for <major>.<minor>.[1-9]+[0-9]*)'
         echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
         echo "::error::${FAILURE_MESSAGE}" ; exit 1
       shell: 'bash'


### PR DESCRIPTION
Trying to run patch release workflow for `9.1.10` [resulted](https://github.com/elastic/apm-server/actions/runs/20914244789/job/60083823300) in a failure: "version is not a patch one but a minor (only support for <major>.<minor>.[1-9]+[0-9]*)"

The failure is not correct, this is a legit patch version.

Update the check to use `.0` to validate patch version. Update the check to use `.0` also to validate minors. Update wording to remove reference to other version, as they may mislead.
