### PR TITLE
Fix testing cloud elastic-agent Dockerfile not copying apm server binary

### DIFF
--- a/testing/cloud/.gitignore
+++ b/testing/cloud/.gitignore
@@ -1,1 +1,4 @@
 *.auto.tfvars
+response.txt
+secret_token_value.json
+scripts/

--- a/testing/docker/elastic-agent/Dockerfile
+++ b/testing/docker/elastic-agent/Dockerfile
@@ -4,4 +4,4 @@ FROM --platform=$TARGETPLATFORM ${ELASTIC_AGENT_IMAGE}
 ARG STACK_VERSION # e.g. 8.5.0-SNAPSHOT
 ARG VCS_REF_SHORT # e.g. abc123
 ARG TARGETARCH
-ONBUILD COPY --chmod=0755 --chown=elastic-agent apm-server-linux-${TARGETARCH} ./data/elastic-agent-${VCS_REF_SHORT}/components/apm-server
+COPY --chmod=0755 --chown=elastic-agent apm-server-linux-${TARGETARCH} ./data/elastic-agent-${VCS_REF_SHORT}/components/apm-server


### PR DESCRIPTION
The Dockerfile was using `ONBUILD COPY` which does not work since there's no next build. Removing `ONBUILD` now properly copies custom APM server binary to the image.