### PR TITLE
docs: update security url to link to central policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -11,7 +11,7 @@ for general questions. If you have a question or an unconfirmed bug, please
 visit the [forums](https://discuss.elastic.co/c/apm).
 
 For security vulnerabilities please only send reports to security@elastic.co.
-See https://www.elastic.co/community/security for more information.
+See https://github.com/elastic/.github/blob/main/SECURITY.md for more information.
 
 Please fill in the following details to help us reproduce the bug:
 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discuss.elastic.co/c/apm
     about: Ask (and answer) questions here.
   - name: Security Vulnerability
-    url: https://www.elastic.co/community/security
+    url: https://github.com/elastic/.github/blob/main/SECURITY.md
     about: Send security vulnerability reports to security@elastic.co.


### PR DESCRIPTION
This PR replaces security URLs with a link to the central security policy.