### PR TITLE
changelog: Add 8.19.12 release notes

### DIFF
--- a/changelogs/8.19.asciidoc
+++ b/changelogs/8.19.asciidoc
@@ -23,7 +23,7 @@ https://github.com/elastic/apm-server/compare/v8.19.11\...v8.19.12[View commits]
 [float]
 ==== Added
 
-- packaging: Update Ironbank base Docker image from ubi9-minimal to ubi10-micro {pull}20295[20295]
+- packaging: Update UBI base Docker image from ubi9-minimal to ubi10-micro {pull}20295[20295]
 
 [float]
 [[apm-release-notes-8.19.11]]


### PR DESCRIPTION
## Summary

This PR adds a changelog entry for version 8.19.12 that includes:

- Use ubi10 for Ironbank images (#20258)

## Related
- #20258