### PR TITLE
packaging(8.19): ubi10-micro does not have sed

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -94,12 +94,14 @@ RUN echo 'apm-server:*:1000:1000::/usr/share/apm-server:/bin/false' >> /etc/pass
 RUN chown -R 1000:1000 /usr/share/apm-server
 
 # remove unnecessary packages in ubuntu-based images
-# use rpm to ignore ubi images
-RUN rpm -v || (dpkg -P --force-depends libgssapi-krb5-2 libtirpc3 libnsl2 libkrb5-3 libk5crypto3 libkrb5support0 && \
-    rm /var/log/dpkg.log)
+# only if rpm is not available and dpkg exists
+RUN if ! rpm -v && dpkg --version; then \
+      dpkg -P --force-depends libgssapi-krb5-2 libtirpc3 libnsl2 libkrb5-3 libk5crypto3 libkrb5support0 && \
+      rm /var/log/dpkg.log; \
+    fi
 # remove unnecessary packages in ubi-based images
-# use dpkg to ignore ubuntu images
-RUN dpkg --version || (rpm -v -e --nodeps libxml2)
+# only if dpkg is not available and rpm exists
+RUN if ! dpkg --version && rpm -v; then rpm -v -e --nodeps libxml2; fi
 
 USER apm-server
 EXPOSE 8200


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Fixes errors in `8.19` when bumping the version to ubi10.

Unfortunately, it failed in the DRA rather than in the CI in the original PR (#20295), and those checks are not mandatory! :/

https://buildkite.com/elastic/apm-server-package/builds/8944

Further details, see https://buildkite.com/elastic/apm-server-package/builds/8946#_

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
