### PR TITLE
packaging: Align dependencies CSV with Dockerfile: UBI 10 micro

### DIFF
--- a/tools/notice/dependencies.csv.tmpl
+++ b/tools/notice/dependencies.csv.tmpl
@@ -5,4 +5,4 @@
 {{- end -}}
 
 name,url,version,revision,license,sourceURL{{ template "depInfo" .Direct }}{{ template "depInfo" .Indirect }}
-Red Hat Universal Base Image minimal,https://catalog.redhat.com/software/containers/ubi10-minimal/615bd9b4075b022acc111bf5,10,,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/10/ubi-minimal-10-source.tar.gz
+Red Hat Universal Base Image micro,https://catalog.redhat.com/software/containers/ubi10-micro/66f2abd91123095c735db44f,10,,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,https://oss-dependencies.elastic.co/red-hat-universal-base-image-micro/10/ubi-micro-10-source.tar.gz


### PR DESCRIPTION
## Summary
The main Docker image (`packaging/docker/Dockerfile`) uses `registry.access.redhat.com/ubi10-micro:latest`. The notice dependencies template (`tools/notice/dependencies.csv.tmpl`) listed **UBI 10 minimal** with an incorrect catalog path (`ubi10-minimal`), so the dependency list did not match the actual base image.

**Source of truth:** Dockerfile.

## Changes
- **Name:** Red Hat Universal Base Image minimal → **micro**
- **Catalog URL:** `.../ubi10-minimal/615bd9b4075b022acc111bf5` → `.../ubi10-micro/66f2abd91123095c735db44f`
- **Source URL:** `.../red-hat-universal-base-image-minimal/10/ubi-minimal-10-source.tar.gz` → `.../red-hat-universal-base-image-micro/10/ubi-micro-10-source.tar.gz`

## Note
Ironbank (`packaging/ironbank/Dockerfile`) uses `redhat/ubi/ubi10:10.1` (full UBI 10). This dependency entry documents the **main** distributed image (ubi10-micro).

Follow up on https://github.com/elastic/apm-server/pull/20258