### PR TITLE
[9.3] packaging: Align dependencies CSV with Dockerfile: UBI 9 micro

### DIFF
--- a/tools/notice/dependencies.csv.tmpl
+++ b/tools/notice/dependencies.csv.tmpl
@@ -5,4 +5,4 @@
 {{- end -}}
 
 name,url,version,revision,license,sourceURL{{ template "depInfo" .Direct }}{{ template "depInfo" .Indirect }}
-Red Hat Universal Base Image minimal,https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5,9,,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/9/ubi-minimal-9-source.tar.gz
+Red Hat Universal Base Image micro,https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58,9,,Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf,https://oss-dependencies.elastic.co/red-hat-universal-base-image-micro/9/ubi-micro-9-source.tar.gz


### PR DESCRIPTION
## Summary
On 9.3, the main Docker image (`packaging/docker/Dockerfile`) uses `registry.access.redhat.com/ubi9/ubi-micro:latest@sha256:e9765516...`. The notice dependencies template listed **UBI 9 minimal**, so the dependency list did not match the actual base image.

**Source of truth:** Dockerfile.

## Changes
- **Name:** Red Hat Universal Base Image minimal → **micro**
- **Catalog URL:** `.../ubi9/ubi-minimal/615bd9b4075b022acc111bf5` → `.../ubi9/ubi-micro/615bdf943f6014fa45ae1b58`
- **Source URL:** `.../red-hat-universal-base-image-minimal/9/ubi-minimal-9-source.tar.gz` → `.../red-hat-universal-base-image-micro/9/ubi-micro-9-source.tar.gz`
- No digest in dep CSV (catalog URL only).

Backport to 9.2 as well