### PR TITLE
bk: skip slack alerts if retried tasks succeeded

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -55,3 +55,4 @@ spec:
           access_level: READ_ONLY
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Currently for pipelines that have steps with auto retries, if there is a failure of a step, even if the subsequent retry succeeds, we receive Slack alerts.
This commits uses new functionality[^1] available in the Buildkite PR Bot to avoid Slack notifications in those cases and changes the settings for all pipelines where we have, or expect to have, retries.

### Why is it important/What is the impact to the user?

Reduce alert noise for non-actionable events in the Slack channel.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

See https://github.com/elastic/logstash/pull/15869
