### PR TITLE
build(deps): align go.elastic.co/apm modules to v2.7.3

### DIFF
--- a/NOTICE-fips.txt
+++ b/NOTICE-fips.txt
@@ -12563,11 +12563,11 @@ Contents of probable licence file $GOMODCACHE/github.com/tklauser/numcpus@v0.11.
 
 --------------------------------------------------------------------------------
 Dependency : go.elastic.co/apm/module/apmelasticsearch/v2
-Version: v2.7.2
+Version: v2.7.3
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmelasticsearch/v2@v2.7.2/LICENSE:
+Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmelasticsearch/v2@v2.7.3/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -15553,11 +15553,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : go.elastic.co/apm/module/apmelasticsearch/v2
-Version: v2.7.2
+Version: v2.7.3
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmelasticsearch/v2@v2.7.2/LICENSE:
+Contents of probable licence file $GOMODCACHE/go.elastic.co/apm/module/apmelasticsearch/v2@v2.7.3/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.15.0 // indirect
 	gitlab.com/digitalxero/go-conventional-commit v1.0.7 // indirect
-	go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.2 // indirect
+	go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.3 // indirect
 	go.elastic.co/ecszap v1.0.3 // indirect
 	go.elastic.co/go-licence-detector v0.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -626,8 +626,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 gitlab.com/digitalxero/go-conventional-commit v1.0.7 h1:8/dO6WWG+98PMhlZowt/YjuiKhqhGlOCwlIV8SqqGh8=
 gitlab.com/digitalxero/go-conventional-commit v1.0.7/go.mod h1:05Xc2BFsSyC5tKhK0y+P3bs0AwUtNuTp+mTpbCU/DZ0=
-go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.2 h1:oy9PA89RuFAbGO4Mhvv0lzwUuHgX1HJUXYZfuR7WJn8=
-go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.2/go.mod h1:Nlv96Nq6AvRhG10NHyWCgU1zWGF9cS8G7l1RXgr3WIs=
+go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.3 h1:QNrBgp9H6j6M6jURYTb/+jReZ1TPmnsMOwKf43gXTKk=
+go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.3/go.mod h1:NtJjbLDyiIfHa1sOfPeuD73mIKB8fg9TjjQJEFXk2Wo=
 go.elastic.co/apm/module/apmhttp/v2 v2.7.3 h1:vVTTIjuKKvV4mfz+Uxg37EM2icyJY7QcONT7c9S2rEw=
 go.elastic.co/apm/module/apmhttp/v2 v2.7.3/go.mod h1:8HRZW1zvCOEAlUNiA86HKXMa+KwTff4vwZnkcq2gjQA=
 go.elastic.co/apm/module/apmotel/v2 v2.7.3 h1:23VIXW2KLfKCfMfqHwlVD0wpjHGP85hLVoVb0uFDNs8=


### PR DESCRIPTION
## Summary
- bump `go.elastic.co/apm/module/apmelasticsearch/v2` from `v2.7.2` to `v2.7.3` so all `go.elastic.co/apm` dependencies are on `v2.7.3`
- run `go mod tidy` to refresh `go.sum`
- regenerate `NOTICE.txt` and `NOTICE-fips.txt` with `make notice`

## Test plan
- [x] Run `go mod tidy`
- [x] Run `make notice`

Made with [Cursor](https://cursor.com)