### PR TITLE
dev-docs: clarify optional test plan creation workflow

### DIFF
--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -56,8 +56,8 @@ Before merging them compare commits between latest minor and the new major versi
 Create a GitHub Issue to track testing of the release branch.
 
 Choose one way to create the initial issue:
-- **Option 1 (manual):** Create it manually using the [test plan issue template](https://github.com/elastic/apm-server/issues/new?assignees=&labels=test-plan&projects=&template=test-plan.md).
-- **Option 2 (optional, recommended):** Run the [`create-test-plan-patch`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan-patch.yml) workflow with the upcoming version, then review and adjust the generated issue content.
+- **Option 1 (recommended):** Run the [`create-test-plan-patch`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan-patch.yml) workflow with the upcoming version, then review and adjust the generated issue content.
+- **Option 2:** Create it manually using the [test plan issue template](https://github.com/elastic/apm-server/issues/new?assignees=&labels=test-plan&projects=&template=test-plan.md).
 
 The issue should include:
 - Test all functional changes applied to the new version.

--- a/dev_docs/RELEASES_8x.md
+++ b/dev_docs/RELEASES_8x.md
@@ -94,8 +94,8 @@ Run the `run-patch-release` with any `8.19.x` version.
 
   Create a GitHub issue for testing the release branch.
   Choose one way to create the initial issue:
-  * **Option 1 (manual):** Create it manually using the [test plan issue template](https://github.com/elastic/apm-server/issues/new?assignees=&labels=test-plan&projects=&template=test-plan.md).
-  * **Option 2 (optional, recommended):** Run the [`create-test-plan-patch`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan-patch.yml) workflow with the upcoming version, then review and adjust the generated issue content.
+  * **Option 1 (recommended):** Run the [`create-test-plan-patch`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan-patch.yml) workflow with the upcoming version, then review and adjust the generated issue content.
+  * **Option 2:** Create it manually using the [test plan issue template](https://github.com/elastic/apm-server/issues/new?assignees=&labels=test-plan&projects=&template=test-plan.md).
   The issue should contain:
   * A link to all PRs in the APM Server repository that need to be tested manually to create an overview over the PRs that need testing.
     Use the `test-plan` label and the version label (create it if it does not exist). For example, [this was 8.13.0 test plan](https://github.com/elastic/apm-server/issues/12822)


### PR DESCRIPTION
## Summary
- update release process docs for 9.x and 8.x to mention `create-test-plan-patch`
- clarify this workflow is optional and can be used instead of manual initial test-plan issue creation
- keep guidance to review and adjust generated issue content

## Test plan
- [ ] Confirm wording appears in `dev_docs/RELEASES.md`
- [ ] Confirm wording appears in `dev_docs/RELEASES_8x.md`
- [ ] Verify workflow link resolves: `https://github.com/elastic/apm-server/actions/workflows/create-test-plan-patch.yml`


Made with [Cursor](https://cursor.com)