### PR TITLE
[8.19] Fix unresolved merge marker in updatecli-compose

### DIFF
--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -2,11 +2,7 @@
 # https://www.updatecli.io/docs/core/compose/
 policies:
   - name: Handle ironbank bumps
-<<<<<<< HEAD
-    policy: ghcr.io/elastic/oblt-updatecli-policies/ironbank/templates:0.5.2@sha256:6a237aea2c621a675d644dd51580bd3c0cb4d48591f54f5ba1c2ba88240fa08b
-=======
     policy: ghcr.io/elastic/oblt-updatecli-policies/ironbank/templates:1.0.0@sha256:fc1c5aacf3025fa34f72c24d5473cbac77be6cc030ff082428cfd1fae49ea08b
->>>>>>> 2899fe2a (updatecli(ironbank): use ubi10 support (#20316))
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/ironbank.yml


### PR DESCRIPTION
## Summary
- Remove leftover Git conflict markers from `updatecli-compose.yaml` in the ironbank policy entry.
- Keep the later value introduced by `updatecli(ironbank): use ubi10 support (#20316)`.
- This appears to be a merge/backport artifact from that backport change.

## Test plan
- [x] Verified `updatecli-compose.yaml` no longer contains `<<<<<<<`, `=======`, or `>>>>>>>` markers.
- [x] Confirmed only the conflict markers were removed and the `1.0.0` policy line is retained.

## Reference
- Backport/source change: #20316 and https://github.com/elastic/apm-server/pull/20319

Made with [Cursor](https://cursor.com)