### PR TITLE
Fix error handling in runScrollSearchQuery

### DIFF
--- a/internal/sourcemap/metadata_fetcher.go
+++ b/internal/sourcemap/metadata_fetcher.go
@@ -385,12 +385,12 @@ func (s *MetadataESFetcher) scrollsearch(ctx context.Context, scrollID string, u
 
 func (s *MetadataESFetcher) runScrollSearchQuery(ctx context.Context, id string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/_search/scroll", nil)
+	if err != nil {
+		return nil, err
+	}
 	q := req.URL.Query()
 	q.Set("scroll", strconv.FormatInt(time.Minute.Milliseconds(), 10)+"ms")
 	q.Set("scroll_id", id)
 	req.URL.RawQuery = q.Encode()
-	if err != nil {
-		return nil, err
-	}
 	return s.esClient.Perform(req)
 }


### PR DESCRIPTION
## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?



when a function returns `(T, error)`, and `T` can be nil on error, all uses of `T` must occur only after confirming that `err == nil`. Here, `http.NewRequestWithContext` returns `(*http.Request, error)` and may return a nil request on error. The fix is to check `err` immediately after the call, before any dereference of `req`, and return appropriately if `err` is non-nil.

Concretely, in `runScrollSearchQuery` in `internal/sourcemap/metadata_fetcher.go`, we should move the error check to immediately follow the call to `http.NewRequestWithContext` and before the usage of `req`.  right after the call, and removing the later `if err != nil` block (or leaving the later block empty is not acceptable). This keeps existing functionality intact: on failure to construct the request, the function returns the error as before; on success, it sets the query parameters and performs the request. 