### PR TITLE
iserver-test: Fix rollover expectation

### DIFF
--- a/integrationservertest/upgrade-config.yaml
+++ b/integrationservertest/upgrade-config.yaml
@@ -79,6 +79,6 @@ lazy-rollover-exceptions:
   # No lazy rollover from any 9.2 patch to any other 9.3 patch.
   - from: "9.2.*"
     to:   "9.3.*"
-  # No lazy rollover from any 9.2 and 9.3 patch to any other 9.4 patch.
-  - from: "[9.2.0 - 9.4.0)"
-    to:   "9.4.*"
+  # No lazy rollover from any 9.2 and 9.3 patch to any other 9.3 patch.
+  - from: "[9.2.0 - 9.3.0)"
+    to:   "9.3.*"


### PR DESCRIPTION
Due to recent change in apm-data: https://github.com/elastic/elasticsearch/pull/143173, 9.3 -> 9.4 will have rollover.