### PR TITLE
smoketest: Remove Oracle Linux from support matrix for now

### DIFF
--- a/testing/smoke/os_matrix.sh
+++ b/testing/smoke/os_matrix.sh
@@ -12,7 +12,8 @@ os_names=(
     "Rocky-9-EC2-Base"
     "AlmaLinux OS 8"
     "AlmaLinux OS 9"
-    "OL8"
-    "OL9"
+    ## Oracle Linux removed for now since they are not available on AMIs.
+    # "OL8"
+    # "OL9"
 )
 


### PR DESCRIPTION
Closes https://github.com/elastic/apm-server/issues/20463.

Oracle Linux is not available right now. Remove it to prevent test from constantly failing.

Follow up issue: https://github.com/elastic/apm-server/issues/20561.