### PR TITLE
Revert "iserver-test: Fix rollover expectation"

### DIFF
--- a/integrationservertest/upgrade-config.yaml
+++ b/integrationservertest/upgrade-config.yaml
@@ -79,6 +79,6 @@ lazy-rollover-exceptions:
   # No lazy rollover from any 9.2 patch to any other 9.3 patch.
   - from: "9.2.*"
     to:   "9.3.*"
-  # No lazy rollover from any 9.2 and 9.3 patch to any other 9.3 patch.
-  - from: "[9.2.0 - 9.3.0)"
-    to:   "9.3.*"
+  # No lazy rollover from any 9.2 and 9.3 patch to any other 9.4 patch.
+  - from: "[9.2.0 - 9.4.0)"
+    to:   "9.4.*"


### PR DESCRIPTION
Reverts elastic/apm-server#20560.

I was wrong about the rollover expectation. Since the apm-data change was ported back to 9.2 and 9.3, the previous expectation should be correct.

I will investigate as to why the previous test failed, but for now we should revert the change.