### PR TITLE
ci: detect ES apm-data plugin changes in patch test plan

### DIFF
--- a/.ci/scripts/generate-test-plan.sh
+++ b/.ci/scripts/generate-test-plan.sh
@@ -112,6 +112,7 @@ NEW_APM_DATA="$(required_module_version build/test-plan-go.mod.new github.com/el
 APM_AGG_DIFF_COMMITS_FILE="build/test-plan-apm-aggregation-diff-commits.txt"
 DOCAPPENDER_DIFF_COMMITS_FILE="build/test-plan-go-docappender-diff-commits.txt"
 APM_DATA_DIFF_COMMITS_FILE="build/test-plan-apm-data-diff-commits.txt"
+ES_APM_DATA_PLUGIN_DIFF_COMMITS_FILE="build/test-plan-es-apm-data-plugin-diff-commits.txt"
 
 awk -F'|' '
   BEGIN { IGNORECASE = 1 }
@@ -293,6 +294,36 @@ collect_external_repo_commits() {
   git -C "${repo_dir}" log --pretty=format:'%H|%an|%ad|%s' --date=short "${old_version}..${new_version}" > "${out_file}" || true
 }
 
+collect_elasticsearch_apm_data_plugin_commits() {
+  local old_tag="$1"
+  local branch="$2"
+  local out_file="$3"
+  local repo_name="elasticsearch"
+  local repo_dir="${REPO_CACHE_DIR}/${repo_name}"
+  local repo_url="https://github.com/elastic/${repo_name}.git"
+  local plugin_path="x-pack/plugin/apm-data"
+
+  : > "${out_file}"
+
+  mkdir -p "${REPO_CACHE_DIR}"
+  if [[ ! -d "${repo_dir}/.git" ]]; then
+    if ! git clone --filter=blob:none --quiet "${repo_url}" "${repo_dir}" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  git -C "${repo_dir}" fetch origin --tags --force --quiet >/dev/null 2>&1 || true
+
+  if ! git -C "${repo_dir}" rev-parse "${old_tag}^{commit}" >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! git -C "${repo_dir}" rev-parse "origin/${branch}^{commit}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  git -C "${repo_dir}" log --pretty=format:'%H|%an|%ad|%s' --date=short "${old_tag}..origin/${branch}" -- "${plugin_path}" > "${out_file}" || true
+}
+
 append_external_repo_details_block() {
   local repo_name="$1"
   local source="$2"
@@ -324,6 +355,7 @@ EOF
 collect_external_repo_commits "apm-aggregation" "${OLD_APM_AGG}" "${NEW_APM_AGG}" "${APM_AGG_DIFF_COMMITS_FILE}"
 collect_external_repo_commits "go-docappender" "${OLD_DOCAPPENDER}" "${NEW_DOCAPPENDER}" "${DOCAPPENDER_DIFF_COMMITS_FILE}"
 collect_external_repo_commits "apm-data" "${OLD_APM_DATA}" "${NEW_APM_DATA}" "${APM_DATA_DIFF_COMMITS_FILE}"
+collect_elasticsearch_apm_data_plugin_commits "${PREVIOUS_TAG}" "${BRANCH}" "${ES_APM_DATA_PLUGIN_DIFF_COMMITS_FILE}"
 
 cat > "${OUTPUT_FILE}" <<EOF
 # Manual Test Plan
@@ -335,8 +367,17 @@ cat > "${OUTPUT_FILE}" <<EOF
 ## ES apm-data plugin
 
 <!-- Add any issues / PRs which were worked on during the milestone release https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/apm-data-->
-TODO: Manually check whether any coordinated ES apm-data plugin changes were done for this release. This is not handled by automation.
+List of changes: https://github.com/elastic/elasticsearch/compare/${PREVIOUS_TAG}...${BRANCH}
+EOF
 
+if [[ -s "${ES_APM_DATA_PLUGIN_DIFF_COMMITS_FILE}" ]]; then
+  append_external_repo_details_block "elasticsearch" "${ES_APM_DATA_PLUGIN_DIFF_COMMITS_FILE}"
+else
+  echo "No changes detected in \`x-pack/plugin/apm-data\` for this release window." >> "${OUTPUT_FILE}"
+  echo >> "${OUTPUT_FILE}"
+fi
+
+cat >> "${OUTPUT_FILE}" <<EOF
 ## apm-aggregation
 
 <!-- Add any issues / PRs which were worked on during the milestone release https://github.com/elastic/apm-aggregation/pulls-->


### PR DESCRIPTION
## Motivation/summary
Automate ES `x-pack/plugin/apm-data` change detection in patch test plan generation, so release managers no longer rely on a manual TODO for this section.

This follows up on the deferred work discussed in [#20368 discussion](https://github.com/elastic/apm-server/pull/20368#discussion_r2822693317) and addresses [#20402](https://github.com/elastic/apm-server/issues/20402).

## What changed
- Added `collect_elasticsearch_apm_data_plugin_commits` to `.ci/scripts/generate-test-plan.sh`.
- Clone/fetch `elastic/elasticsearch` in the existing test-plan repo cache.
- Compare `${PREVIOUS_TAG}..origin/${BRANCH}` scoped to `x-pack/plugin/apm-data`.
- Replace the manual TODO in the generated markdown with:
  - compare link to Elasticsearch (`vX.Y.(Z-1)...X.Y`)
  - commit details block when plugin changes are detected
  - explicit "no changes detected" fallback otherwise

## Checklist
- [ ] Update CHANGELOG.asciidoc
- [ ] Documentation has been updated

## How to test these changes
- `bash -n .ci/scripts/generate-test-plan.sh`
- `bash .ci/scripts/generate-test-plan.sh 8.19.13`
- `bash .ci/scripts/generate-test-plan.sh 9.3.2`

For `9.3.2`, the generated `ES apm-data plugin` section includes detected plugin commits.

## Related issues
- Closes #20402

Made with [Cursor](https://cursor.com)