### PR TITLE
ci: keep ES apm-data plugin section expanded in patch test plan

### DIFF
--- a/.ci/scripts/generate-test-plan.sh
+++ b/.ci/scripts/generate-test-plan.sh
@@ -327,13 +327,25 @@ collect_elasticsearch_apm_data_plugin_commits() {
 append_external_repo_details_block() {
   local repo_name="$1"
   local source="$2"
+  local collapsed="${3:-true}"
   [[ -s "${source}" ]] || return 0
 
-  cat >> "${OUTPUT_FILE}" <<EOF
+  if [[ "${collapsed}" != "true" && "${collapsed}" != "false" ]]; then
+    echo "Error: collapsed flag for ${repo_name} commit section must be 'true' or 'false', got '${collapsed}'" >&2
+    return 1
+  fi
+
+  if [[ "${collapsed}" == "true" ]]; then
+    cat >> "${OUTPUT_FILE}" <<EOF
 <details>
 <summary>Commits in ${repo_name} diff</summary>
 
 EOF
+  else
+    echo "Commits in ${repo_name} diff:" >> "${OUTPUT_FILE}"
+    echo >> "${OUTPUT_FILE}"
+  fi
+
   awk -F'|' -v repo="${repo_name}" '
     {
       hash = $1
@@ -345,11 +357,14 @@ EOF
       printf "- [`%s`](https://github.com/elastic/%s/commit/%s): `%s` (%s on %s)\n", short, repo, hash, subject, author, date
     }
   ' "${source}" >> "${OUTPUT_FILE}"
-  cat >> "${OUTPUT_FILE}" <<EOF
 
+  if [[ "${collapsed}" == "true" ]]; then
+    cat >> "${OUTPUT_FILE}" <<EOF
 </details>
-
 EOF
+  fi
+
+  echo >> "${OUTPUT_FILE}"
 }
 
 collect_external_repo_commits "apm-aggregation" "${OLD_APM_AGG}" "${NEW_APM_AGG}" "${APM_AGG_DIFF_COMMITS_FILE}"
@@ -371,7 +386,7 @@ List of changes: https://github.com/elastic/elasticsearch/compare/${PREVIOUS_TAG
 EOF
 
 if [[ -s "${ES_APM_DATA_PLUGIN_DIFF_COMMITS_FILE}" ]]; then
-  append_external_repo_details_block "elasticsearch" "${ES_APM_DATA_PLUGIN_DIFF_COMMITS_FILE}"
+  append_external_repo_details_block "elasticsearch" "${ES_APM_DATA_PLUGIN_DIFF_COMMITS_FILE}" "false"
 else
   echo "No changes detected in \`x-pack/plugin/apm-data\` for this release window." >> "${OUTPUT_FILE}"
   echo >> "${OUTPUT_FILE}"


### PR DESCRIPTION
## Motivation/summary

Follow up to #20645: the generated `ES apm-data plugin` section should render commit entries directly, not inside a collapsed `<details>` block.

## What changed

* Extended `append_external_repo_details_block` with an optional boolean `collapsed` flag (default `true`).
* Added strict validation so only `true|false` values are accepted.
* For `ES apm-data plugin`, call the helper with `collapsed=false` so commit entries are always visible.
* Preserved existing behavior for all other repository sections.

### Example output diff (`9.3.2`)

```diff
--- build/test-plan-9.3.2.before.md
+++ build/test-plan-9.3.2.after.md
@@ -8,13 +8,10 @@
 
 <!-- Add any issues / PRs which were worked on during the milestone release https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/apm-data-->
 List of changes: https://github.com/elastic/elasticsearch/compare/v9.3.1...9.3
-<details>
-<summary>Commits in elasticsearch diff</summary>
+Commits in elasticsearch diff:
 
 - [`e15d128f`](https://github.com/elastic/elasticsearch/commit/e15d128f2bc4edb05d73acb495744470e026a1cd): `apm-data: explicit map of timestamp.us to long (#143173) (#143593)` (Edoardo Tenani on 2026-03-04)
 
-</details>
-
 ## apm-aggregation
```

## Checklist

* [ ] Update CHANGELOG.asciidoc
* [ ] Documentation has been updated

## How to test these changes

* `bash -n .ci/scripts/generate-test-plan.sh`
* `bash .ci/scripts/generate-test-plan.sh 9.3.2`
* Verify the `ES apm-data plugin` commit list is visible without expanding a details block.

## Related issues

* Follow-up to #20645

Made with [Cursor](https://cursor.com)