### PR TITLE
test: Fix flaky systemtest TestMonitoring

### DIFF
--- a/systemtest/monitoring_test.go
+++ b/systemtest/monitoring_test.go
@@ -92,7 +92,10 @@ func TestMonitoring(t *testing.T) {
 	batches := gjson.GetBytes(metrics.Libbeat, "output.events.batches")
 	assert.NotZero(t, batches.Int())
 
-	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.active").Int())
+	// output.events.active is an instantaneous gauge. It may be non-zero
+	// if there are other events, e.g. aggregated metrics, in flight.
+	// Therefore, we assert presence of output.events.active value but not its value.
+	assert.Equal(t, gjson.Number, gjson.GetBytes(metrics.Libbeat, "output.events.active").Type)
 	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.failed").Int())
 	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.toomany").Int())
 	assert.GreaterOrEqual(t, gjson.GetBytes(metrics.Libbeat, "output.events.total").Int(), int64(N))
@@ -100,7 +103,7 @@ func TestMonitoring(t *testing.T) {
 	assert.Equal(t, "elasticsearch", gjson.GetBytes(metrics.Libbeat, "output.type").Str)
 
 	bulkRequestsAvailable := gjson.GetBytes(metrics.Output, "elasticsearch.bulk_requests.available")
-	assert.Greater(t, bulkRequestsAvailable.Int(), int64(10))
+	assert.Greater(t, bulkRequestsAvailable.Int(), int64(0))
 	assert.Equal(t, batches.Int(), gjson.GetBytes(metrics.Output, "elasticsearch.bulk_requests.completed").Int())
 	assert.Equal(t, int64(1), gjson.GetBytes(metrics.Output, "elasticsearch.indexers.active").Int())
 	assert.Zero(t, gjson.GetBytes(metrics.Output, "elasticsearch.indexers.created").Int())


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Fix flaky systemtest TestMonitoring by asserting type not value

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes https://github.com/elastic/apm-server/issues/20436
