### PR TITLE
feat: move docker labels to opencontainers

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -33,33 +33,36 @@ ARG VCS_REF
 
 # Statically defined labels.
 LABEL \
-  org.label-schema.schema-version="1.0" \
-  org.label-schema.vendor="Elastic" \
-  org.label-schema.license="Elastic License" \
-  org.label-schema.name="apm-server" \
-  org.label-schema.url="https://www.elastic.co/apm" \
-  org.label-schema.vcs-url="github.com/elastic/apm-server" \
-  io.k8s.description="Elastic APM Server" \
-  io.k8s.display-name="Apm-Server image" \
-  org.opencontainers.image.licenses="Elastic License" \
+  org.opencontainers.image.authors="obs-ds-intake-services" \
+  org.opencontainers.image.base.name="registry.access.redhat.com/ubi10-micro:latest" \
+  org.opencontainers.image.description="Elastic APM Server" \
+  org.opencontainers.image.documentation="https://www.elastic.co/docs/solutions/observability/apm/apm-server" \
+  org.opencontainers.image.licenses="Elastic-2.0" \
+  org.opencontainers.image.source="https://github.com/elastic/apm-server" \
   org.opencontainers.image.title="Apm-Server" \
+  org.opencontainers.image.url="https://github.com/elastic/apm-server" \
   org.opencontainers.image.vendor="Elastic" \
-  name="apm-server" \
-  maintainer="infra@elastic.co" \
-  vendor="Elastic" \
-  release="1" \
-  url="https://www.elastic.co/apm" \
-  summary="apm-server" \
-  license="Elastic License" \
-  description="Elastic APM Server"
+  io.k8s.description="Elastic APM Server" \
+  io.k8s.display-name="Apm-Server image"
 
 # Dynamic labels, only set in published images.
 LABEL \
-  org.label-schema.build-date=${BUILD_DATE} \
-  org.label-schema.version=${VERSION} \
-  org.label-schema.vcs-ref=${VCS_REF} \
   org.opencontainers.image.created=${BUILD_DATE} \
-  version=${VERSION}
+  org.opencontainers.image.revision=${VCS_REF} \
+  org.opencontainers.image.version=${VERSION}
+
+# Overwrite ubi base image non-standard labels
+LABEL \
+  build-date="" \
+  description="" \
+  maintainer="" \
+  name="" \
+  release="" \
+  summary="" \
+  url="" \
+  vcs-ref="" \
+  vendor="" \
+  version=""
 
 ENV ELASTIC_CONTAINER="true"
 

--- a/packaging/docker/Dockerfile.fips
+++ b/packaging/docker/Dockerfile.fips
@@ -30,33 +30,23 @@ ARG VCS_REF
 
 # Statically defined labels.
 LABEL \
-  org.label-schema.schema-version="1.0" \
-  org.label-schema.vendor="Elastic" \
-  org.label-schema.license="Elastic License" \
-  org.label-schema.name="apm-server" \
-  org.label-schema.url="https://www.elastic.co/apm" \
-  org.label-schema.vcs-url="github.com/elastic/apm-server" \
-  io.k8s.description="Elastic APM Server" \
-  io.k8s.display-name="Apm-Server image" \
-  org.opencontainers.image.licenses="Elastic License" \
+  org.opencontainers.image.authors="obs-ds-intake-services" \
+  org.opencontainers.image.base.name="docker.elastic.co/wolfi/chainguard-base-fips:latest" \
+  org.opencontainers.image.description="Elastic APM Server" \
+  org.opencontainers.image.documentation="https://www.elastic.co/docs/solutions/observability/apm/apm-server" \
+  org.opencontainers.image.licenses="Elastic-2.0" \
+  org.opencontainers.image.source="https://github.com/elastic/apm-server" \
   org.opencontainers.image.title="Apm-Server" \
+  org.opencontainers.image.url="https://github.com/elastic/apm-server" \
   org.opencontainers.image.vendor="Elastic" \
-  name="apm-server" \
-  maintainer="infra@elastic.co" \
-  vendor="Elastic" \
-  release="1" \
-  url="https://www.elastic.co/apm" \
-  summary="apm-server" \
-  license="Elastic License" \
-  description="Elastic APM Server"
+  io.k8s.description="Elastic APM Server" \
+  io.k8s.display-name="Apm-Server image"
 
 # Dynamic labels, only set in published images.
 LABEL \
-  org.label-schema.build-date=${BUILD_DATE} \
-  org.label-schema.version=${VERSION} \
-  org.label-schema.vcs-ref=${VCS_REF} \
   org.opencontainers.image.created=${BUILD_DATE} \
-  version=${VERSION}
+  org.opencontainers.image.revision=${VCS_REF} \
+  org.opencontainers.image.version=${VERSION}
 
 ENV ELASTIC_CONTAINER "true"
 

--- a/packaging/docker/Dockerfile.wolfi
+++ b/packaging/docker/Dockerfile.wolfi
@@ -31,33 +31,23 @@ ARG VCS_REF
 
 # Statically defined labels.
 LABEL \
-  org.label-schema.schema-version="1.0" \
-  org.label-schema.vendor="Elastic" \
-  org.label-schema.license="Elastic License" \
-  org.label-schema.name="apm-server" \
-  org.label-schema.url="https://www.elastic.co/apm" \
-  org.label-schema.vcs-url="github.com/elastic/apm-server" \
-  io.k8s.description="Elastic APM Server" \
-  io.k8s.display-name="Apm-Server image" \
-  org.opencontainers.image.licenses="Elastic License" \
+  org.opencontainers.image.authors="obs-ds-intake-services" \
+  org.opencontainers.image.base.name="cgr.dev/chainguard/static:latest" \
+  org.opencontainers.image.description="Elastic APM Server" \
+  org.opencontainers.image.documentation="https://www.elastic.co/docs/solutions/observability/apm/apm-server" \
+  org.opencontainers.image.licenses="Elastic-2.0" \
+  org.opencontainers.image.source="https://github.com/elastic/apm-server" \
   org.opencontainers.image.title="Apm-Server" \
+  org.opencontainers.image.url="https://github.com/elastic/apm-server" \
   org.opencontainers.image.vendor="Elastic" \
-  name="apm-server" \
-  maintainer="infra@elastic.co" \
-  vendor="Elastic" \
-  release="1" \
-  url="https://www.elastic.co/apm" \
-  summary="apm-server" \
-  license="Elastic License" \
-  description="Elastic APM Server"
+  io.k8s.description="Elastic APM Server" \
+  io.k8s.display-name="Apm-Server image"
 
 # Dynamic labels, only set in published images.
 LABEL \
-  org.label-schema.build-date=${BUILD_DATE} \
-  org.label-schema.version=${VERSION} \
-  org.label-schema.vcs-ref=${VCS_REF} \
   org.opencontainers.image.created=${BUILD_DATE} \
-  version=${VERSION}
+  org.opencontainers.image.revision=${VCS_REF} \
+  org.opencontainers.image.version=${VERSION}
 
 ENV ELASTIC_CONTAINER "true"
 


### PR DESCRIPTION
## Motivation/summary

drop deprecated org.label-schema labels and use
opencontainers labels everywhere.

Overwrite ubi base image non-standard labels to avoid confusion.

label-schema is deprecated and images should move to https://specs.opencontainers.org/image-spec/annotations/

This should help with retrieving base image and maintainers from our images.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
