### PR TITLE
Change benchmark schedule to Wednesdays at 17:00

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -58,7 +58,7 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: '0 17 * * *' # Scheduled regular benchmarks.
+    - cron: '0 17 * * 3' # Scheduled regular benchmarks.
     - cron: '0 0 1 * *' # Scheduled PGO benchmarks.
 
 env:


### PR DESCRIPTION
As no big features are being added lately, we can save some costs by only running the benchmarks once a week. If failed, it will be to the sdh on duty to investigate issues.