### PR TITLE
Fix patch release workflow version

### DIFF
--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version to be bumped to (semver format: major.minor.patch). e.g. when told "bump the project and documentation versions on the 9.2 branch to 9.2.6", fill in `9.2.6`.'
+        description: 'The upcoming feature freeze / release version (semver format: major.minor.patch)'
         required: true
         type: string
 
@@ -38,13 +38,27 @@ jobs:
           version: ${{ inputs.version }}
           type: 'patch'
 
-  run-patch:
+  bump-patch:
     runs-on: ubuntu-latest
     needs: [ prepare ]
+    steps:
+      - id: bump
+        shell: bash
+        run: |
+          VERSION="${{ needs.prepare.outputs.release-version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "bump-version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+  run-patch:
+    runs-on: ubuntu-latest
+    needs: [ prepare, bump-patch ]
     env:
       RELEASE_BRANCH: ${{ needs.prepare.outputs.release-branch }}
       RELEASE_TYPE: ${{ needs.prepare.outputs.release-type }}
-      RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
+      BUMP_VERSION: ${{ needs.bump-patch.outputs.bump-version }}
     steps:
       - name: Get token
         id: get_token
@@ -89,7 +103,7 @@ jobs:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ env.SLACK_CHANNEL }}
           message: |-
-            PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ env.RELEASE_VERSION }}` have been created.
+            PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ env.BUMP_VERSION }}` have been created.
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 
       - if: failure()

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The upcoming feature freeze / release version (semver format: major.minor.patch)'
+        description: 'The current to-be-released version (semver format: major.minor.patch). E.g. If the feature freeze / release for 9.3.1 is coming, use 9.3.1.'
         required: true
         type: string
 

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -76,7 +76,7 @@ jobs:
           # 0 indicates all history for all branches and tags.
           fetch-depth: 0
           # Use the makefile in the given release branch.
-          ref: ${{ env.RELEASE_BRANCH }}
+          # ref: ${{ env.RELEASE_BRANCH }}
           token: ${{ steps.get_token.outputs.token }}
 
       # Required to use a service account, otherwise PRs created by

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -41,6 +41,8 @@ jobs:
   bump-patch:
     runs-on: ubuntu-latest
     needs: [ prepare ]
+    outputs:
+      bump-version: ${{ steps.bump.outputs.bump-version }}
     steps:
       - id: bump
         shell: bash

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -106,6 +106,7 @@ jobs:
           channel-id: ${{ env.SLACK_CHANNEL }}
           message: |-
             PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ env.BUMP_VERSION }}` have been created.
+            Remember to create PRs for the changelogs separately!
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 
       - if: failure()

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -38,29 +38,12 @@ jobs:
           version: ${{ inputs.version }}
           type: 'patch'
 
-  bump-patch:
-    runs-on: ubuntu-latest
-    needs: [ prepare ]
-    outputs:
-      bump-version: ${{ steps.bump.outputs.bump-version }}
-    steps:
-      - id: bump
-        shell: bash
-        run: |
-          VERSION="${{ needs.prepare.outputs.release-version }}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
-          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
-          echo "bump-version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
   run-patch:
     runs-on: ubuntu-latest
-    needs: [ prepare, bump-patch ]
+    needs: [ prepare ]
     env:
       RELEASE_BRANCH: ${{ needs.prepare.outputs.release-branch }}
       RELEASE_TYPE: ${{ needs.prepare.outputs.release-type }}
-      BUMP_VERSION: ${{ needs.bump-patch.outputs.bump-version }}
     steps:
       - name: Get token
         id: get_token
@@ -75,9 +58,17 @@ jobs:
         with:
           # 0 indicates all history for all branches and tags.
           fetch-depth: 0
-          # Use the makefile in the given release branch.
-          # ref: ${{ env.RELEASE_BRANCH }}
           token: ${{ steps.get_token.outputs.token }}
+
+      - id: bump_version
+        shell: bash
+        run: |
+          VERSION="${{ needs.prepare.outputs.release-version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
       # Required to use a service account, otherwise PRs created by
       # GitHub bot won't trigger any CI builds.
@@ -98,6 +89,7 @@ jobs:
       - run: make patch-release
         env:
           GH_TOKEN: ${{ steps.get_token.outputs.token }}
+          BUMP_VERSION: ${{ steps.bump_version.outputs.version }}
 
       - if: success()
         uses: elastic/oblt-actions/slack/send@v1
@@ -105,7 +97,7 @@ jobs:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ env.SLACK_CHANNEL }}
           message: |-
-            PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ env.BUMP_VERSION }}` have been created.
+            PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ steps.bump_version.outputs.version }}` have been created.
             Remember to create PRs for the changelogs separately!
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 

--- a/release.mk
+++ b/release.mk
@@ -44,8 +44,6 @@ ifneq ($(shell command -v gh 2>/dev/null),)
 CURRENT_RELEASE ?= $(shell gh release list --exclude-drafts --exclude-pre-releases --repo elastic/apm-server --limit 10 --json tagName --jq '.[].tagName|select(. | startswith("v$(PROJECT_MAJOR_VERSION)"))' | sed 's|v||g' | sort -r | head -n 1)
 RELEASE_BRANCH ?= $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION)
 NEXT_PROJECT_MINOR_VERSION ?= $(PROJECT_MAJOR_VERSION).$(shell expr $(PROJECT_MINOR_VERSION) + 1).0
-NEXT_RELEASE ?= $(RELEASE_BRANCH).$(shell expr $(PROJECT_PATCH_VERSION) + 1)
-BRANCH_PATCH = update-$(NEXT_RELEASE)
 endif
 
 # BASE_BRANCH select by release type (default patch)
@@ -80,7 +78,6 @@ minor-release:
 	@echo "INFO: Create release branch and update new version $(RELEASE_VERSION)"
 	$(MAKE) create-branch NAME=$(RELEASE_BRANCH) BASE=$(BASE_BRANCH)
 	$(MAKE) update-version VERSION=$(RELEASE_VERSION)
-	$(MAKE) update-version-makefile VERSION=$(PROJECT_MAJOR_VERSION)\.$(PROJECT_MINOR_VERSION)
 	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update version $(RELEASE_VERSION)"
 
 	@echo "INFO: Create feature branch and update the versions. Target branch $(BASE_BRANCH)"
@@ -111,12 +108,11 @@ major-release:
 .PHONY: patch-release
 patch-release:
 	@echo "INFO: Create feature branch and update the versions. Target branch $(RELEASE_BRANCH)"
-	$(MAKE) create-branch NAME=$(BRANCH_PATCH) BASE=$(RELEASE_BRANCH)
+	$(MAKE) create-branch NAME="update-$(BUMP_VERSION)" BASE=$(RELEASE_BRANCH)
 	$(MAKE) update-version VERSION=$(BUMP_VERSION)
-	$(MAKE) update-version-makefile VERSION=$(PROJECT_MAJOR_VERSION)\.$(PROJECT_MINOR_VERSION)
 	$(MAKE) create-commit COMMIT_MESSAGE="$(RELEASE_BRANCH): update versions to $(BUMP_VERSION)"
 	@echo "INFO: Push changes to $(PROJECT_OWNER)/apm-server and create the relevant Pull Requests"
-	$(MAKE) create-pull-request BRANCH=$(BRANCH_PATCH) TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(BUMP_VERSION): update versions" BODY="Merge on request by the Release Manager." BACKPORT_LABEL=backport-skip
+	$(MAKE) create-pull-request BRANCH="update-$(BUMP_VERSION)" TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(BUMP_VERSION): update versions" BODY="Merge on request by the Release Manager." BACKPORT_LABEL=backport-skip
 
 ############################################
 ## Internal make goals to bump versions
@@ -160,13 +156,6 @@ update-version:
 	if [ -f "internal/version/version.go" ]; then \
 		$(SED) -E -e 's#(Version[[:blank:]]*)=[[:blank:]]*"[0-9]+\.[0-9]+\.[0-9]+#\1= "$(VERSION)#g' internal/version/version.go; \
 	fi
-
-## Update project version in the Makefile.
-.PHONY: update-version-makefile
-update-version-makefile: VERSION=$${VERSION}
-update-version-makefile:
-	@echo ">> update-version-makefile"
-	$(SED) -E -e 's#BEATS_VERSION\s*\?=\s*(([0-9]+\.[0-9]+)|main)#BEATS_VERSION\?=$(VERSION)#g' Makefile
 
 ############################################
 ## Internal make goals to interact with Git

--- a/release.mk
+++ b/release.mk
@@ -78,6 +78,7 @@ minor-release:
 	@echo "INFO: Create release branch and update new version $(RELEASE_VERSION)"
 	$(MAKE) create-branch NAME=$(RELEASE_BRANCH) BASE=$(BASE_BRANCH)
 	$(MAKE) update-version VERSION=$(RELEASE_VERSION)
+	$(MAKE) update-version-makefile VERSION=$(PROJECT_MAJOR_VERSION)\.$(PROJECT_MINOR_VERSION)
 	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update version $(RELEASE_VERSION)"
 
 	@echo "INFO: Create feature branch and update the versions. Target branch $(BASE_BRANCH)"
@@ -156,6 +157,13 @@ update-version:
 	if [ -f "internal/version/version.go" ]; then \
 		$(SED) -E -e 's#(Version[[:blank:]]*)=[[:blank:]]*"[0-9]+\.[0-9]+\.[0-9]+#\1= "$(VERSION)#g' internal/version/version.go; \
 	fi
+
+## Update project version in the Makefile.
+.PHONY: update-version-makefile
+update-version-makefile: VERSION=$${VERSION}
+update-version-makefile:
+	@echo ">> update-version-makefile"
+	$(SED) -E -e 's#BEATS_VERSION\s*\?=\s*(([0-9]+\.[0-9]+)|main)#BEATS_VERSION\?=$(VERSION)#g' Makefile
 
 ############################################
 ## Internal make goals to interact with Git

--- a/release.mk
+++ b/release.mk
@@ -112,19 +112,11 @@ major-release:
 patch-release:
 	@echo "INFO: Create feature branch and update the versions. Target branch $(RELEASE_BRANCH)"
 	$(MAKE) create-branch NAME=$(BRANCH_PATCH) BASE=$(RELEASE_BRANCH)
-	$(MAKE) update-version VERSION=$(RELEASE_VERSION)
+	$(MAKE) update-version VERSION=$(BUMP_VERSION)
 	$(MAKE) update-version-makefile VERSION=$(PROJECT_MAJOR_VERSION)\.$(PROJECT_MINOR_VERSION)
-	$(MAKE) create-commit COMMIT_MESSAGE="$(RELEASE_BRANCH): update versions to $(RELEASE_VERSION)"
+	$(MAKE) create-commit COMMIT_MESSAGE="$(RELEASE_BRANCH): update versions to $(BUMP_VERSION)"
 	@echo "INFO: Push changes to $(PROJECT_OWNER)/apm-server and create the relevant Pull Requests"
-	$(MAKE) create-pull-request BRANCH=$(BRANCH_PATCH) TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(RELEASE_VERSION): update versions" BODY="Merge on request by the Release Manager." BACKPORT_LABEL=backport-skip
-
-	@echo "INFO: Create feature branch and update the versions. Target branch $(BASE_BRANCH)"
-	$(MAKE) create-branch NAME=update-$(RELEASE_VERSION) BASE=$(BASE_BRANCH)
-	$(MAKE) update-changelog VERSION=$(RELEASE_VERSION)
-	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update changelogs for $(RELEASE_BRANCH) release"
-	@echo "INFO: Push changes to $(PROJECT_OWNER)/apm-server and create the relevant Pull Requests"
-	git push origin update-$(RELEASE_VERSION)
-	$(MAKE) create-pull-request BRANCH=update-$(RELEASE_VERSION) TARGET_BRANCH=$(BASE_BRANCH) TITLE="$(RELEASE_BRANCH): update release notes" BODY="Merge as soon as the GitHub checks are green."
+	$(MAKE) create-pull-request BRANCH=$(BRANCH_PATCH) TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(BUMP_VERSION): update versions" BODY="Merge on request by the Release Manager." BACKPORT_LABEL=backport-skip
 
 ############################################
 ## Internal make goals to bump versions

--- a/release.mk
+++ b/release.mk
@@ -104,7 +104,7 @@ major-release:
 
 # This is the contract with the GitHub action .github/workflows/run-patch-release.yml
 # The GitHub action will provide the below environment variables:
-#  - RELEASE_VERSION
+#  - BUMP_VERSION
 #
 .PHONY: patch-release
 patch-release:


### PR DESCRIPTION
## Motivation/summary

- Fix patch release workflow to take in to-be-released version, but use bumped version for update PRs.
- Remove changelog PRs from workflow, since we create them manually.
- Remove `update-version-makefile` since it is no longer used.

## How to test these changes

Run the workflow.

Example: https://github.com/elastic/apm-server/actions/runs/24068944954.

## Related issues

Closes https://github.com/elastic/apm-server/issues/20731.
