### PR TITLE
docs: add 8.14 TLS 1.2 RSA handshake breaking change

### DIFF
--- a/changelogs/8.14.asciidoc
+++ b/changelogs/8.14.asciidoc
@@ -45,6 +45,10 @@ https://github.com/elastic/apm-server/compare/v8.13.2\...v8.14.0[View commits]
 - Remove error reason from logs when Elasticsearch returns unavailable_shards_exception {pull}13287[13287]
 
 [float]
+==== Breaking Changes
+- TLS 1.2 handshakes with RSA key exchange ciphers can fail at runtime (for example, `AES128-GCM-SHA256`) even when startup succeeds, due to Go 1.22 default TLS behavior. Workaround: set `GODEBUG=tlsrsakex=1` on the APM Server process. {issue}20879[20879]
+
+[float]
 ==== Added
 - OpenTelemetry Distro Name will now be used for `agent.name` and `agent.version` {pull}12940[12940]
 - Add support for setting the `host.id` via IntakeV2 {pull}12940[12940]

--- a/changelogs/all-breaking-changes.asciidoc
+++ b/changelogs/all-breaking-changes.asciidoc
@@ -19,6 +19,23 @@ This change should not impact most users as this field is not used by the APM UI
 For more details, see https://github.com/elastic/apm-server/pull/11632[PR #11632]
 // end::811-bc[]
 
+// tag::814-bc[]
+[float]
+[[breaking-changes-8.14]]
+=== 8.14
+
+The following breaking changes are introduced in APM version 8.14.0:
+
+[float]
+==== TLS 1.2 RSA key exchange cipher negotiation may fail at runtime
+When using TLS 1.2 and relying on default TLS cipher behavior, APM Server can start successfully but fail TLS handshake at runtime for peers that require RSA key exchange ciphers, such as `AES128-GCM-SHA256`.
+This change comes from Go 1.22 TLS defaults, introduced in APM version 8.14.0.
+
+For more details, see https://github.com/elastic/apm-server/issues/20879[Issue #20879].
+
+Workaround: set `GODEBUG=tlsrsakex=1` on the APM Server process.
+// end::814-bc[]
+
 // tag::810-bc[]
 [float]
 [[breaking-changes-8.10]]

--- a/changelogs/all-breaking-changes.asciidoc
+++ b/changelogs/all-breaking-changes.asciidoc
@@ -7,18 +7,6 @@
 This section describes the breaking changes and deprecations introduced in this release
 and previous minor versions.
 
-// tag::811-bc[]
-[float]
-[[breaking-changes-8.11]]
-=== 8.11
-
-The following breaking changes are introduced in APM version 8.11.0:
-
-- The `ecs.version` field has been removed from APM data streams.
-This change should not impact most users as this field is not used by the APM UI.
-For more details, see https://github.com/elastic/apm-server/pull/11632[PR #11632]
-// end::811-bc[]
-
 // tag::814-bc[]
 [float]
 [[breaking-changes-8.14]]
@@ -35,6 +23,18 @@ For more details, see https://github.com/elastic/apm-server/issues/20879[Issue #
 
 Workaround: set `GODEBUG=tlsrsakex=1` on the APM Server process.
 // end::814-bc[]
+
+// tag::811-bc[]
+[float]
+[[breaking-changes-8.11]]
+=== 8.11
+
+The following breaking changes are introduced in APM version 8.11.0:
+
+- The `ecs.version` field has been removed from APM data streams.
+This change should not impact most users as this field is not used by the APM UI.
+For more details, see https://github.com/elastic/apm-server/pull/11632[PR #11632]
+// end::811-bc[]
 
 // tag::810-bc[]
 [float]

--- a/changelogs/all-breaking-changes.asciidoc
+++ b/changelogs/all-breaking-changes.asciidoc
@@ -14,14 +14,9 @@ and previous minor versions.
 
 The following breaking changes are introduced in APM version 8.14.0:
 
-[float]
-==== TLS 1.2 RSA key exchange cipher negotiation may fail at runtime
-When using TLS 1.2 and relying on default TLS cipher behavior, APM Server can start successfully but fail TLS handshake at runtime for peers that require RSA key exchange ciphers, such as `AES128-GCM-SHA256`.
-This change comes from Go 1.22 TLS defaults, introduced in APM version 8.14.0.
+- TLS 1.2 handshakes with RSA key exchange ciphers can fail at runtime (for example, `AES128-GCM-SHA256`) even when startup succeeds, due to Go 1.22 default TLS behavior. Workaround: set `GODEBUG=tlsrsakex=1` on the APM Server process.
 
 For more details, see https://github.com/elastic/apm-server/issues/20879[Issue #20879].
-
-Workaround: set `GODEBUG=tlsrsakex=1` on the APM Server process.
 // end::814-bc[]
 
 // tag::811-bc[]


### PR DESCRIPTION
## Motivation/summary

This PR documents a TLS behavior change introduced with the Go 1.22 toolchain that first landed in APM Server 8.14.0.

It adds a user-facing breaking-change note in two places:
- `changelogs/8.14.asciidoc` under the `8.14.0` release section (`==== Breaking Changes`)
- `changelogs/all-breaking-changes.asciidoc` under the `=== 8.14` section

The note explains that TLS 1.2 handshakes with RSA key exchange ciphers can fail at runtime even when startup succeeds, and documents the temporary workaround: set `GODEBUG=tlsrsakex=1` on the APM Server process.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

1. Inspect `changelogs/8.14.asciidoc` and verify `APM version 8.14.0` includes a `==== Breaking Changes` subsection describing this TLS behavior and workaround.
2. Inspect `changelogs/all-breaking-changes.asciidoc` and verify the `=== 8.14` section exists in correct descending order before `=== 8.11`.
3. Confirm both entries mention the workaround `GODEBUG=tlsrsakex=1` and reference issue `#20879`.
4. (Validation context) Runtime repro details are captured in issue `#20879`.

## Related issues

Fixes https://github.com/elastic/apm-server/issues/20877
Related: https://github.com/elastic/apm-server/issues/20879