### PR TITLE
Fix HTTP/2 SETTINGS mismatch connection failure in gmux

### DIFF
--- a/NOTICE-fips.txt
+++ b/NOTICE-fips.txt
@@ -1344,11 +1344,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-transpo
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/gmux
-Version: v0.3.2
+Version: v0.3.3
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/gmux@v0.3.2/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/gmux@v0.3.3/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004
@@ -5273,11 +5273,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Dependency : google.golang.org/grpc
-Version: v1.79.3
+Version: v1.80.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/google.golang.org/grpc@v1.79.3/LICENSE:
+Contents of probable licence file $GOMODCACHE/google.golang.org/grpc@v1.80.0/LICENSE:
 
 
                                  Apache License

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1344,11 +1344,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-transpo
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/gmux
-Version: v0.3.2
+Version: v0.3.3
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/gmux@v0.3.2/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/gmux@v0.3.3/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004
@@ -5273,11 +5273,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Dependency : google.golang.org/grpc
-Version: v1.79.3
+Version: v1.80.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/google.golang.org/grpc@v1.79.3/LICENSE:
+Contents of probable licence file $GOMODCACHE/google.golang.org/grpc@v1.80.0/LICENSE:
 
 
                                  Apache License

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/elastic/elastic-agent-libs v0.33.3
 	github.com/elastic/elastic-agent-system-metrics v0.14.3
 	github.com/elastic/elastic-transport-go/v8 v8.8.0
-	github.com/elastic/gmux v0.3.2
+	github.com/elastic/gmux v0.3.3
 	github.com/elastic/go-docappender/v2 v2.12.1
 	github.com/elastic/go-freelru v0.16.0
 	github.com/elastic/go-sysinfo v1.15.4
@@ -46,7 +46,7 @@ require (
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.40.0
 	golang.org/x/time v0.14.0
-	google.golang.org/grpc v1.79.3
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )
 

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/elastic/elastic-agent-system-metrics v0.14.3 h1:v867kcgCVguOX3AYIHEVn
 github.com/elastic/elastic-agent-system-metrics v0.14.3/go.mod h1:JNfnZrC0viAjlJRUzQKKuMpDlXgjXBn4WdWEXQF7jcA=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
 github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/gmux v0.3.2 h1:cb721R+fe/rt/jVNyBP5HDQsEwLD2wSKfPD2Sk6adDk=
-github.com/elastic/gmux v0.3.2/go.mod h1:OD6oYrno+SV3pyl1ArdWCjlExZ+FJOfoSaFqnFeldBQ=
+github.com/elastic/gmux v0.3.3 h1:HEM7HOO10CKJUau/9WcnbQAPlo9EW85f0tWfMEidVaU=
+github.com/elastic/gmux v0.3.3/go.mod h1:kRSvlDg0rSzWmBamH/kNRFl+NoMKDU4VufUT98PnGHU=
 github.com/elastic/go-docappender/v2 v2.12.1 h1:ROOQyT4bjUTt2y36vJG4269UaDV63jY3pF301+DKCx4=
 github.com/elastic/go-docappender/v2 v2.12.1/go.mod h1:3eEqeo9gaXyDYWTXZ0J5n6A07UpfbvogpsUHRu1E+rI=
 github.com/elastic/go-elasticsearch/v8 v8.19.1 h1:0iEGt5/Ds9MNVxEp3hqLsXdbe6SjleaVHONg/FuR09Q=
@@ -775,8 +775,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171/go.mod h1:M5krXqk4GhBKvB596udGL3UyjL4I1+cTbK0orROM9ng=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 h1:ndE4FoJqsIceKP2oYSnUZqhTdYufCYYkqwtFzfrhI7w=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
-google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
+google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
 google.golang.org/grpc/examples v0.0.0-20231016154744-cb430bed4d27 h1:EB/3dtnYKOItaNPpOI/HmOCGbVZUiXcstRfiuxN+cFg=
 google.golang.org/grpc/examples v0.0.0-20231016154744-cb430bed4d27/go.mod h1:Crtq1t+mykyL5d6PR3z8zCxKx/Qjq/mlPWDPoWJANYA=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=

--- a/systemtest/http2_test.go
+++ b/systemtest/http2_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package systemtest
 
 import (

--- a/systemtest/http2_test.go
+++ b/systemtest/http2_test.go
@@ -1,0 +1,192 @@
+package systemtest
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+
+	"github.com/elastic/apm-server/systemtest/apmservertest"
+)
+
+// TestHTTP2OverTLS performs a sanity check on http2 request response flow.
+func TestHTTP2OverTLS(t *testing.T) {
+	srv := apmservertest.NewUnstartedServerTB(t)
+	require.NoError(t, srv.StartTLS())
+
+	tlsConf := srv.TLS.Clone()
+	tlsConf.NextProtos = []string{"h2"}
+	client := &http.Client{
+		Transport: &http.Transport{
+			ForceAttemptHTTP2: true,
+			TLSClientConfig:   tlsConf,
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Get(srv.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, 2, resp.ProtoMajor)
+	require.NotZero(t, resp.StatusCode)
+}
+
+// TestHTTP2OverTLSFramingConsistency performs a raw HTTP/2 exchange and asserts
+// that SETTINGS remain consistent across the connection while a request/response
+// completes without GOAWAY.
+// This is to prevent reoccurrence of regression in https://github.com/elastic/apm-server/issues/20887
+func TestHTTP2OverTLSFramingConsistency(t *testing.T) {
+	srv := apmservertest.NewUnstartedServerTB(t)
+	require.NoError(t, srv.StartTLS())
+
+	tlsConf := srv.TLS.Clone()
+	tlsConf.NextProtos = []string{"h2"}
+	var (
+		mu       sync.Mutex
+		recorded *recordingConn
+	)
+	h2Transport := &http2.Transport{
+		TLSClientConfig: tlsConf,
+		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+			conn, err := tls.DialWithDialer(&net.Dialer{}, network, addr, cfg)
+			if err != nil {
+				return nil, err
+			}
+			rc := &recordingConn{Conn: conn}
+			mu.Lock()
+			recorded = rc
+			mu.Unlock()
+			return rc, nil
+		},
+	}
+	client := &http.Client{
+		Transport: h2Transport,
+		Timeout:   5 * time.Second,
+	}
+	resp, err := client.Get(srv.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.NotZero(t, resp.StatusCode)
+
+	mu.Lock()
+	require.NotNil(t, recorded)
+	serverFrames := recorded.Bytes()
+	mu.Unlock()
+
+	nonACKSettings, statusCode, sawGoAway := collectSettingsAndStatusFromBytes(t, serverFrames)
+
+	require.False(t, sawGoAway, "server should not send GOAWAY for a valid request")
+	require.NotZero(t, statusCode, "response must include a non-zero :status")
+	require.GreaterOrEqual(t, len(nonACKSettings), 2, "expected sniffing and backend SETTINGS frames")
+
+	first := nonACKSettings[0]
+	for i := 1; i < len(nonACKSettings); i++ {
+		require.Equalf(t, first, nonACKSettings[i], "non-ACK SETTINGS #%d differs from first SETTINGS frame", i+1)
+	}
+}
+
+type recordingConn struct {
+	net.Conn
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (c *recordingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.mu.Lock()
+		_, _ = c.buf.Write(p[:n])
+		c.mu.Unlock()
+	}
+	return n, err
+}
+
+func (c *recordingConn) Bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]byte(nil), c.buf.Bytes()...)
+}
+
+func collectSettingsAndStatusFromBytes(t *testing.T, data []byte) ([][]http2.Setting, int, bool) {
+	t.Helper()
+
+	var (
+		nonACKSettings [][]http2.Setting
+		sawGoAway      bool
+		statusCode     int
+		done           bool
+		headerBlock    bytes.Buffer
+	)
+
+	decoder := hpack.NewDecoder(4096, func(hf hpack.HeaderField) {
+		if hf.Name == ":status" {
+			code, err := strconv.Atoi(hf.Value)
+			require.NoError(t, err)
+			statusCode = code
+		}
+	})
+
+	decodeHeaders := func(endStream bool) {
+		_, err := decoder.Write(headerBlock.Bytes())
+		require.NoError(t, err)
+		require.NoError(t, decoder.Close())
+		headerBlock.Reset()
+		if endStream {
+			done = true
+		}
+	}
+	framer := http2.NewFramer(io.Discard, bytes.NewReader(data))
+
+	for !done && !sawGoAway {
+		f, err := framer.ReadFrame()
+		require.NoError(t, err)
+
+		switch f := f.(type) {
+		case *http2.SettingsFrame:
+			if f.IsAck() {
+				continue
+			}
+			var settings []http2.Setting
+			require.NoError(t, f.ForeachSetting(func(s http2.Setting) error {
+				settings = append(settings, s)
+				return nil
+			}))
+			nonACKSettings = append(nonACKSettings, settings)
+		case *http2.HeadersFrame:
+			_, err := headerBlock.Write(f.HeaderBlockFragment())
+			require.NoError(t, err)
+			if f.HeadersEnded() {
+				decodeHeaders(f.StreamEnded())
+			}
+		case *http2.ContinuationFrame:
+			_, err := headerBlock.Write(f.HeaderBlockFragment())
+			require.NoError(t, err)
+			if f.HeadersEnded() {
+				decodeHeaders(false)
+			}
+		case *http2.DataFrame:
+			if f.StreamEnded() {
+				done = true
+			}
+		case *http2.GoAwayFrame:
+			sawGoAway = true
+		}
+	}
+
+	return nonACKSettings, statusCode, sawGoAway
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

`apm-server` currently vendors a `gmux` version that can trigger HTTP/2 connection failures with strict clients after ALPN negotiates `h2` (for example, curl/nghttp2 reporting framing/peer-close errors). The root problem is a SETTINGS mismatch sequence introduced by `golang.org/x/net/http2` starting at `v0.50.0` when multiplexers emit an initial sniffing SETTINGS frame before handing off to `http2.Server`.

This PR bumps `gmux` to the fix from [elastic/gmux#97](https://github.com/elastic/gmux/pull/97), which makes gmux mirror the backend `http2.Server` initial SETTINGS (instead of sending an empty sniffing SETTINGS), avoiding illegal SETTINGS value changes on the same connection. That restores HTTP/2 interoperability for affected clients while keeping gmux behavior resilient to backend initial-settings changes.

Before:
```
=== RUN   TestHTTP2OverTLSFramingConsistency
    http2_test.go:99: 
        	Error Trace:	/home/carson/projects/apm-server/systemtest/http2_test.go:99
        	Error:      	Not equal: 
        	            	expected: []http2.Setting(nil)
        	            	actual  : []http2.Setting{http2.Setting{ID:0x5, Val:0x100000}, http2.Setting{ID:0x3, Val:0xfa}, http2.Setting{ID:0x6, Val:0x100140}, http2.Setting{ID:0x1, Val:0x1000}, http2.Setting{ID:0x4, Val:0x100000}, http2.Setting{ID:0x9, Val:0x1}}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,27 @@
        	            	-([]http2.Setting) <nil>
        	            	+([]http2.Setting) (len=6) {
        	            	+ (http2.Setting) {
        	            	+  ID: (http2.SettingID) 5,
        	            	+  Val: (uint32) 1048576
        	            	+ },
        	            	+ (http2.Setting) {
        	            	+  ID: (http2.SettingID) 3,
        	            	+  Val: (uint32) 250
        	            	+ },
        	            	+ (http2.Setting) {
        	            	+  ID: (http2.SettingID) 6,
        	            	+  Val: (uint32) 1048896
        	            	+ },
        	            	+ (http2.Setting) {
        	            	+  ID: (http2.SettingID) 1,
        	            	+  Val: (uint32) 4096
        	            	+ },
        	            	+ (http2.Setting) {
        	            	+  ID: (http2.SettingID) 4,
        	            	+  Val: (uint32) 1048576
        	            	+ },
        	            	+ (http2.Setting) {
        	            	+  ID: (http2.SettingID) 9,
        	            	+  Val: (uint32) 1
        	            	+ }
        	            	+}
        	            	 
        	Test:       	TestHTTP2OverTLSFramingConsistency
        	Messages:   	non-ACK SETTINGS #2 differs from first SETTINGS frame
    server.go:144: log file: /home/carson/projects/apm-server/systemtest/logs/TestHTTP2OverTLSFramingConsistency/apm-server
--- FAIL: TestHTTP2OverTLSFramingConsistency (10.03s)
```

After:
```
=== RUN   TestHTTP2OverTLSFramingConsistency
--- PASS: TestHTTP2OverTLSFramingConsistency (10.03s)
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
    - Proposed bugfix release-notes entry for `docs/release-notes/index.md`:
> Fixed an HTTP/2 SETTINGS mismatch in gmux that could cause strict HTTP/2 clients (for example, curl/nghttp2) to fail connections after ALPN negotiates `h2`.
- [x] Documentation has been updated: known issue https://github.com/elastic/apm-server/pull/20911

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

See new system test

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #20887

