### PR TITLE
iservertest: Change lazy rollover for 9.2 - 9.5 to be more general

### DIFF
--- a/integrationservertest/upgrade-config.yaml
+++ b/integrationservertest/upgrade-config.yaml
@@ -76,9 +76,6 @@ lazy-rollover-exceptions:
   # No lazy rollover from any 9.* patch to any other 9.* patch iff minor is the same.
   - from: "9.x.*"
     to:   "9.x.*"
-  # No lazy rollover from any 9.2 patch to any other 9.3 patch.
-  - from: "9.2.*"
-    to:   "9.3.*"
-  # No lazy rollover from any 9.2 and 9.3 patch to any other 9.4 patch.
-  - from: "[9.2.0 - 9.4.0)"
-    to:   "9.4.*"
+  # No lazy rollover from any 9.2 - 9.5 patch to any other 9.2 - 9.5 patch.
+  - from: "[9.2.0 - 9.6.0)"
+    to:   "[9.2.0 - 9.6.0)"


### PR DESCRIPTION
With the release of 9.4.0 we now have 9.5.0-SNAPSHOT for testing, which means adding new lazy rollover exceptions since there were no apm-data changes in between. This PR consolidates the newly added rule with the other previous rules on 9.2 - 9.4 patches.

Workflow run: https://github.com/elastic/apm-server/actions/runs/24649199698.


For reference, lazy rollover happens when the version [here](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/apm-data/src/main/resources/resources.yaml) changes.