### PR TITLE
support minor release create test plan workflow

### DIFF
--- a/.ci/scripts/generate-test-plan.sh
+++ b/.ci/scripts/generate-test-plan.sh
@@ -17,13 +17,22 @@ MAJOR="${BASH_REMATCH[1]}"
 MINOR="${BASH_REMATCH[2]}"
 PATCH="${BASH_REMATCH[3]}"
 
-if (( PATCH == 0 )); then
-  echo "Error: Cannot infer previous tag for x.y.0 releases. Patch version must be >= 1"
-  exit 1
-fi
-
 BRANCH="${MAJOR}.${MINOR}"
-PREVIOUS_TAG="v${MAJOR}.${MINOR}.$((PATCH - 1))"
+
+if (( PATCH == 0 )); then
+  if (( MINOR == 0 )); then
+    echo "Error: Cannot infer previous tag for x.0.0 releases"
+    exit 1
+  fi
+  PREVIOUS_MINOR=$((MINOR - 1))
+  PREVIOUS_TAG=$(git tag -l "v${MAJOR}.${PREVIOUS_MINOR}.*" | sort -V | tail -1)
+  if [[ -z "${PREVIOUS_TAG}" ]]; then
+    echo "Error: Could not find any tags for v${MAJOR}.${PREVIOUS_MINOR}.*"
+    exit 1
+  fi
+else
+  PREVIOUS_TAG="v${MAJOR}.${MINOR}.$((PATCH - 1))"
+fi
 OUTPUT_FILE="build/test-plan-${VERSION}.md"
 REPO_CACHE_DIR="build/test-plan-repos"
 
@@ -35,8 +44,13 @@ if ! git rev-parse "${PREVIOUS_TAG}" >/dev/null 2>&1; then
 fi
 
 if ! git rev-parse "origin/${BRANCH}" >/dev/null 2>&1; then
-  echo "Error: Release branch origin/${BRANCH} does not exist in this repository"
-  exit 1
+  if (( PATCH == 0 )) && git rev-parse "origin/main" >/dev/null 2>&1; then
+    echo "Release branch origin/${BRANCH} not found, falling back to origin/main"
+    BRANCH="main"
+  else
+    echo "Error: Release branch origin/${BRANCH} does not exist in this repository"
+    exit 1
+  fi
 fi
 
 echo "Upcoming release: v${VERSION}"

--- a/.github/workflows/create-test-plan.yml
+++ b/.github/workflows/create-test-plan.yml
@@ -1,11 +1,11 @@
 ---
-name: create-test-plan-patch
+name: create-test-plan
 
 on:
   workflow_dispatch:
     inputs:
       upcoming_release:
-        description: 'Upcoming release version (e.g., 9.2.6)'
+        description: 'Upcoming release version (e.g., 9.2.6 for patch, 9.2.0 for minor)'
         required: true
         type: string
 

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -54,7 +54,7 @@ Before merging them compare commits between latest minor and the new major versi
 Create a GitHub Issue to track testing of the release branch.
 
 Choose one way to create the initial issue:
-- **Option 1 (recommended):** Run the [`create-test-plan-patch`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan-patch.yml) workflow with the upcoming version, then review and adjust the generated issue content.
+- **Option 1 (recommended):** Run the [`create-test-plan`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan.yml) workflow with the upcoming version, then review and adjust the generated issue content.
 - **Option 2:** Create it manually using the [test plan issue template](https://github.com/elastic/apm-server/issues/new?assignees=&labels=test-plan&projects=&template=test-plan.md).
 
 The issue should include:

--- a/dev_docs/RELEASES_8x.md
+++ b/dev_docs/RELEASES_8x.md
@@ -94,7 +94,7 @@ Run the `run-patch-release` with any `8.19.x` version.
 
   Create a GitHub issue for testing the release branch.
   Choose one way to create the initial issue:
-  * **Option 1 (recommended):** Run the [`create-test-plan-patch`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan-patch.yml) workflow with the upcoming version, then review and adjust the generated issue content.
+  * **Option 1 (recommended):** Run the [`create-test-plan`](https://github.com/elastic/apm-server/actions/workflows/create-test-plan.yml) workflow with the upcoming version, then review and adjust the generated issue content.
   * **Option 2:** Create it manually using the [test plan issue template](https://github.com/elastic/apm-server/issues/new?assignees=&labels=test-plan&projects=&template=test-plan.md).
   The issue should contain:
   * A link to all PRs in the APM Server repository that need to be tested manually to create an overview over the PRs that need testing.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

This PR will allow us to automate the test plan creation for minor releases

Changes that were done:
- update the `generate-test-plan.sh` to now handle minor releases
- update the documentation
- renamed `create-test-plan-patch` to `create-test-plan` to avoid confusion now that it handles both minor and patch releases
- update documentation

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

```sh
# since the workflow name has been releases I invoked the script from my terminal e.g.

➜  via 🐹 v1.26.2 bash .ci/scripts/generate-test-plan.sh 9.4.0
Upcoming release: v9.4.0
Release branch: 9.4
Previous tag: v9.3.3
Commits analyzed: 165
Generated build/test-plan-9.4.0.md

# then checked the output by 
cat build/test-plan-9.4.0.md


# did this for the following versions:
# 9.4.0 <- minor 
# 9.3.4 <- patch
# 9.0.0 <- when minor version is zero it should error out
# 9.6.0 <- when no tags exist for 9.5.* then it will error out as well
```

for convenience here are the test plans that were created by invoking this script:
- 9.3.4: https://github.com/aelnahas/apm-server/issues/3
- 9.4.0: https://github.com/aelnahas/apm-server/issues/2
they werent created by the workflow rather I ran the script and pasted the output test plan as an issue to my fork.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
https://github.com/elastic/apm-server/issues/20454
