### PR TITLE
docs: add upper bounds to timestamp.us known issue

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -22,7 +22,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} The spans in the trace waterfall aren't correctly rendered
 
-*Elastic Stack versions: >=8.15.0, >=9.0.0 when using APM Server shipping data through non-Elasticsearch output (Logstash, Redis, Kafka, Console)*<br>
+*Elastic Stack versions: >=8.15.0 and <8.19.13, >=9.0.0 and <9.2.7, >=9.3.0 and <9.3.2 when using APM Server shipping data through non-Elasticsearch output (Logstash, Redis, Kafka, Console)*<br>
 *Environments: ECH, ECE, ECK, and self-managed*
 
 When using APM Server with non-Elasticsearch outputs shipping to an Elasticsearch version 8.15.0 or more recent, the trace waterfall will render spans incorrectly.
@@ -120,7 +120,7 @@ To work around this issue, we can temporarily introduce an explicit mapping for 
 Adapt the rollover requests depending on the namespaces you might be using. In case you had already customizations to
 the `traces-apm@custom` component templates, add an explicit mapping of the field `timestamp.us` to `long`.
 
-This bug will be fixed in 8.19.13, 9.2.7, 9.3.2, 9.4.0
+This bug was fixed in 8.19.13, 9.2.7, 9.3.2, 9.4.0
 
 Once Elasticsearch is upgraded to a version containing the fix, it would be ideal to remove the `traces-apm@custom` component template using `DELETE _component_template/traces-apm@custom` and trigger a manual rollover (or wait for it to happen automatically).
 


### PR DESCRIPTION
## Motivation/summary

Adds upper bounds to the affected Elastic Stack version range for the `timestamp.us`/trace waterfall known issue introduced in #20508. The fix landed in Elasticsearch via elastic/elasticsearch#143173 and is available from 8.19.13, 9.2.7, 9.3.2 onwards.
 
Updates wording: "will be fixed" → "was fixed" as the fix has shipped.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

N/A

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Closes #20515
