### PR TITLE
monitoring: eagerly register apm-server metric instruments

### DIFF
--- a/internal/agentcfg/elasticsearch.go
+++ b/internal/agentcfg/elasticsearch.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/elastic/apm-server/internal/elasticsearch"
 	"github.com/elastic/apm-server/internal/logs"
+	"github.com/elastic/apm-server/internal/otelmetric"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -73,7 +74,7 @@ type ElasticsearchFetcher struct {
 
 	tracer trace.Tracer
 
-	esCacheEntriesCount     metric.Int64Gauge
+	esCacheEntriesCount     metric.Int64UpDownCounter
 	esFetchCount            metric.Int64Counter
 	esFetchFallbackCount    metric.Int64Counter
 	esFetchUnavailableCount metric.Int64Counter
@@ -92,13 +93,13 @@ func NewElasticsearchFetcher(
 ) *ElasticsearchFetcher {
 	meter := mp.Meter("github.com/elastic/apm-server/internal/agentcfg")
 
-	esCacheEntriesCount, _ := meter.Int64Gauge("apm-server.agentcfg.elasticsearch.cache.entries.count")
-	esFetchCount, _ := meter.Int64Counter("apm-server.agentcfg.elasticsearch.fetch.es")
-	esFetchFallbackCount, _ := meter.Int64Counter("apm-server.agentcfg.elasticsearch.fetch.fallback")
-	esFetchUnavailableCount, _ := meter.Int64Counter("apm-server.agentcfg.elasticsearch.fetch.unavailable")
-	esFetchInvalidCount, _ := meter.Int64Counter("apm-server.agentcfg.elasticsearch.fetch.invalid")
-	esCacheRefreshSuccesses, _ := meter.Int64Counter("apm-server.agentcfg.elasticsearch.cache.refresh.successes")
-	esCacheRefreshFailures, _ := meter.Int64Counter("apm-server.agentcfg.elasticsearch.cache.refresh.failures")
+	esCacheEntriesCount := otelmetric.NewInt64UpDownCounter(meter, "apm-server.agentcfg.elasticsearch.cache.entries.count")
+	esFetchCount := otelmetric.NewInt64Counter(meter, "apm-server.agentcfg.elasticsearch.fetch.es")
+	esFetchFallbackCount := otelmetric.NewInt64Counter(meter, "apm-server.agentcfg.elasticsearch.fetch.fallback")
+	esFetchUnavailableCount := otelmetric.NewInt64Counter(meter, "apm-server.agentcfg.elasticsearch.fetch.unavailable")
+	esFetchInvalidCount := otelmetric.NewInt64Counter(meter, "apm-server.agentcfg.elasticsearch.fetch.invalid")
+	esCacheRefreshSuccesses := otelmetric.NewInt64Counter(meter, "apm-server.agentcfg.elasticsearch.cache.refresh.successes")
+	esCacheRefreshFailures := otelmetric.NewInt64Counter(meter, "apm-server.agentcfg.elasticsearch.cache.refresh.failures")
 
 	logger = logger.Named("agentcfg")
 	tracer := tp.Tracer("github.com/elastic/apm-server/internal/agentcfg")
@@ -263,10 +264,15 @@ func (f *ElasticsearchFetcher) refreshCache(ctx context.Context) (err error) {
 	f.clearScroll(ctx, scrollID)
 
 	f.mu.Lock()
+	delta := int64(len(buffer) - len(f.cache))
 	f.cache = buffer
 	f.mu.Unlock()
 	f.cacheInitialized.Store(true)
-	f.esCacheEntriesCount.Record(context.Background(), int64(len(f.cache)))
+	// esCacheEntriesCount is an UpDownCounter tracking the current cache
+	// size as the running sum of size deltas. This keeps every apm-server
+	// monitoring instrument counter-shaped, which has well-defined
+	// eager-emit semantics (Add(0) is a no-op); see internal/otelmetric.
+	f.esCacheEntriesCount.Add(context.Background(), delta)
 	f.last = time.Now()
 	return nil
 }

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -577,39 +577,67 @@ func getScalarInt64(data metricdata.Aggregation) (int64, bool) {
 	return 0, false
 }
 
+// getScalarFloat64 returns a single-value, dimensionless gauge or counter
+// float value, or (0, false) if the data does not match these constraints.
+func getScalarFloat64(data metricdata.Aggregation) (float64, bool) {
+	switch data := data.(type) {
+	case metricdata.Sum[float64]:
+		if len(data.DataPoints) != 1 || data.DataPoints[0].Attributes.Len() != 0 {
+			break
+		}
+		return data.DataPoints[0].Value, true
+	case metricdata.Gauge[float64]:
+		if len(data.DataPoints) != 1 || data.DataPoints[0].Attributes.Len() != 0 {
+			break
+		}
+		return data.DataPoints[0].Value, true
+	}
+	return 0, false
+}
+
 // addAPMServerMetricsToMap adds simple scalar metrics with the "apm-server." prefix
-// to the map.
+// to the map. Both int64 and float64 instruments are supported.
 func addAPMServerMetricsToMap(beatsMetrics map[string]any, metrics []metricdata.Metrics) {
 	for _, m := range metrics {
-		if suffix, ok := strings.CutPrefix(m.Name, "apm-server."); ok {
-			if value, ok := getScalarInt64(m.Data); ok {
-				current := beatsMetrics
-				suffixSlice := strings.Split(suffix, ".")
-				for i := 0; i < len(suffixSlice)-1; i++ {
-					k := suffixSlice[i]
-					if _, ok := current[k]; !ok {
-						current[k] = make(map[string]any)
-					}
-					if currentmap, ok := current[k].(map[string]any); ok {
-						current = currentmap
-					}
-				}
-				current[suffixSlice[len(suffixSlice)-1]] = value
+		suffix, ok := strings.CutPrefix(m.Name, "apm-server.")
+		if !ok {
+			continue
+		}
+		var value any
+		if v, ok := getScalarInt64(m.Data); ok {
+			value = v
+		} else if v, ok := getScalarFloat64(m.Data); ok {
+			value = v
+		} else {
+			continue
+		}
+		current := beatsMetrics
+		suffixSlice := strings.Split(suffix, ".")
+		for i := 0; i < len(suffixSlice)-1; i++ {
+			k := suffixSlice[i]
+			if _, ok := current[k]; !ok {
+				current[k] = make(map[string]any)
+			}
+			if currentmap, ok := current[k].(map[string]any); ok {
+				current = currentmap
 			}
 		}
+		current[suffixSlice[len(suffixSlice)-1]] = value
 	}
 }
 
 func reportOnKey(v monitoring.Visitor, m map[string]any) {
 	for key, value := range m {
-		if valueMap, ok := value.(map[string]any); ok {
+		switch value := value.(type) {
+		case map[string]any:
 			v.OnRegistryStart()
 			v.OnKey(key)
-			reportOnKey(v, valueMap)
+			reportOnKey(v, value)
 			v.OnRegistryFinished()
-		}
-		if valueMetric, ok := value.(int64); ok {
-			monitoring.ReportInt(v, key, valueMetric)
+		case int64:
+			monitoring.ReportInt(v, key, value)
+		case float64:
+			monitoring.ReportFloat(v, key, value)
 		}
 	}
 }

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -651,17 +651,17 @@ func reportOnKey(v monitoring.Visitor, m map[string]any) {
 	}
 }
 
-// addDocappenderLibbeatOutputMetrics adapts go-docappender's OTel metrics to
-// the libbeat.output.* monitoring tree. Every reported field is accumulated
-// into a local variable and reported unconditionally, so the full field set
-// appears with zero values even before docappender has published anything.
-// This keeps /stats's libbeat.output.* shape stable from process start, which
-// downstream mapping-regeneration tooling relies on.
+// Adapt go-docappender's OTel metrics to beats stack monitoring metrics,
+// with a mixture of libbeat-specific and apm-server specific metric names.
 func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visitor, sm metricdata.ScopeMetrics) {
-	var acked, active, batches, failed, toomany, total, writeBytes int64
+	var writeBytes int64
+
+	v.OnRegistryStart()
+	v.OnKey("events")
 	for _, m := range sm.Metrics {
 		switch m.Name {
 		case "elasticsearch.events.processed":
+			var acked, toomany, failed int64
 			data, _ := m.Data.(metricdata.Sum[int64])
 			for _, dp := range data.DataPoints {
 				status, ok := dp.Attributes.Value(attribute.Key("status"))
@@ -678,13 +678,16 @@ func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visito
 					failed += dp.Value
 				}
 			}
+			monitoring.ReportInt(v, "acked", acked)
+			monitoring.ReportInt(v, "failed", failed)
+			monitoring.ReportInt(v, "toomany", toomany)
 		case "elasticsearch.events.count":
 			if value, ok := getScalarInt64(m.Data); ok {
-				total = value
+				monitoring.ReportInt(v, "total", value)
 			}
 		case "elasticsearch.events.queued":
 			if value, ok := getScalarInt64(m.Data); ok {
-				active = value
+				monitoring.ReportInt(v, "active", value)
 			}
 		case "elasticsearch.flushed.bytes":
 			if value, ok := getScalarInt64(m.Data); ok {
@@ -692,45 +695,33 @@ func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visito
 			}
 		case "elasticsearch.bulk_requests.count":
 			if value, ok := getScalarInt64(m.Data); ok {
-				batches = value
+				monitoring.ReportInt(v, "batches", value)
 			}
 		}
 	}
-
-	v.OnRegistryStart()
-	v.OnKey("events")
-	monitoring.ReportInt(v, "acked", acked)
-	monitoring.ReportInt(v, "active", active)
-	monitoring.ReportInt(v, "batches", batches)
-	monitoring.ReportInt(v, "failed", failed)
-	monitoring.ReportInt(v, "toomany", toomany)
-	monitoring.ReportInt(v, "total", total)
 	v.OnRegistryFinished()
 
-	v.OnRegistryStart()
-	v.OnKey("write")
-	monitoring.ReportInt(v, "bytes", writeBytes)
-	v.OnRegistryFinished()
+	if writeBytes > 0 {
+		v.OnRegistryStart()
+		v.OnKey("write")
+		monitoring.ReportInt(v, "bytes", writeBytes)
+		v.OnRegistryFinished()
+	}
 }
 
-// addDocappenderLibbeatPipelineMetrics adapts go-docappender's OTel metrics
-// to the libbeat.pipeline.* monitoring tree. Reports the field unconditionally
-// so it surfaces at zero before any publish, matching the eager-emission
-// contract used by addDocappenderLibbeatOutputMetrics.
 func addDocappenderLibbeatPipelineMetrics(ctx context.Context, v monitoring.Visitor, sm metricdata.ScopeMetrics) {
-	var total int64
-	for _, m := range sm.Metrics {
-		if m.Name == "elasticsearch.events.count" {
-			if value, ok := getScalarInt64(m.Data); ok {
-				total = value
-			}
-		}
-	}
-
 	v.OnRegistryStart()
 	defer v.OnRegistryFinished()
 	v.OnKey("events")
-	monitoring.ReportInt(v, "total", total)
+
+	for _, m := range sm.Metrics {
+		switch m.Name {
+		case "elasticsearch.events.count":
+			if value, ok := getScalarInt64(m.Data); ok {
+				monitoring.ReportInt(v, "total", value)
+			}
+		}
+	}
 }
 
 // Add non-libbeat Elasticsearch output metrics under "output.elasticsearch".

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -558,21 +558,27 @@ func (b *Beat) registerStatsMetrics() {
 	})
 }
 
+// scalarValue extracts the single dimensionless data point from a Sum or
+// Gauge aggregation's DataPoints slice, or returns (zero, false) if the
+// data has the wrong shape: zero or many points, or attribute-tagged
+// points.
+func scalarValue[T int64 | float64](dp []metricdata.DataPoint[T]) (T, bool) {
+	if len(dp) != 1 || dp[0].Attributes.Len() != 0 {
+		var zero T
+		return zero, false
+	}
+	return dp[0].Value, true
+}
+
 // getScalarInt64 returns a single-value, dimensionless
 // gauge or counter integer value, or (0, false) if the
 // data does not match these constraints.
 func getScalarInt64(data metricdata.Aggregation) (int64, bool) {
 	switch data := data.(type) {
 	case metricdata.Sum[int64]:
-		if len(data.DataPoints) != 1 || data.DataPoints[0].Attributes.Len() != 0 {
-			break
-		}
-		return data.DataPoints[0].Value, true
+		return scalarValue(data.DataPoints)
 	case metricdata.Gauge[int64]:
-		if len(data.DataPoints) != 1 || data.DataPoints[0].Attributes.Len() != 0 {
-			break
-		}
-		return data.DataPoints[0].Value, true
+		return scalarValue(data.DataPoints)
 	}
 	return 0, false
 }
@@ -582,15 +588,9 @@ func getScalarInt64(data metricdata.Aggregation) (int64, bool) {
 func getScalarFloat64(data metricdata.Aggregation) (float64, bool) {
 	switch data := data.(type) {
 	case metricdata.Sum[float64]:
-		if len(data.DataPoints) != 1 || data.DataPoints[0].Attributes.Len() != 0 {
-			break
-		}
-		return data.DataPoints[0].Value, true
+		return scalarValue(data.DataPoints)
 	case metricdata.Gauge[float64]:
-		if len(data.DataPoints) != 1 || data.DataPoints[0].Attributes.Len() != 0 {
-			break
-		}
-		return data.DataPoints[0].Value, true
+		return scalarValue(data.DataPoints)
 	}
 	return 0, false
 }

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -612,17 +612,22 @@ func addAPMServerMetricsToMap(beatsMetrics map[string]any, metrics []metricdata.
 			continue
 		}
 		current := beatsMetrics
-		suffixSlice := strings.Split(suffix, ".")
-		for i := 0; i < len(suffixSlice)-1; i++ {
-			k := suffixSlice[i]
-			if _, ok := current[k]; !ok {
-				current[k] = make(map[string]any)
+		// SplitAfterSeq yields each segment with its trailing "." preserved,
+		// except the last. CutSuffix tells us which we're looking at: hasDot
+		// true => intermediate (descend), false => leaf (assign).
+		for seg := range strings.SplitAfterSeq(suffix, ".") {
+			name, hasDot := strings.CutSuffix(seg, ".")
+			if !hasDot {
+				current[name] = value
+				continue
 			}
-			if currentmap, ok := current[k].(map[string]any); ok {
-				current = currentmap
+			if _, ok := current[name]; !ok {
+				current[name] = make(map[string]any)
+			}
+			if next, ok := current[name].(map[string]any); ok {
+				current = next
 			}
 		}
-		current[suffixSlice[len(suffixSlice)-1]] = value
 	}
 }
 

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -701,12 +701,10 @@ func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visito
 	}
 	v.OnRegistryFinished()
 
-	if writeBytes > 0 {
-		v.OnRegistryStart()
-		v.OnKey("write")
-		monitoring.ReportInt(v, "bytes", writeBytes)
-		v.OnRegistryFinished()
-	}
+	v.OnRegistryStart()
+	v.OnKey("write")
+	monitoring.ReportInt(v, "bytes", writeBytes)
+	v.OnRegistryFinished()
 }
 
 func addDocappenderLibbeatPipelineMetrics(ctx context.Context, v monitoring.Visitor, sm metricdata.ScopeMetrics) {

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -30,6 +30,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
@@ -489,34 +490,59 @@ func (b *Beat) registerStateMetrics() {
 func (b *Beat) registerStatsMetrics() {
 	statsRegistry := b.Monitoring.StatsRegistry()
 	libbeatRegistry := statsRegistry.GetOrCreateRegistry("libbeat")
+
+	// Per-callback persistent state for the libbeat.output.* and
+	// libbeat.pipeline.* sub-trees. Both structs zero-init, so every
+	// field surfaces in /stats from process start (which downstream
+	// mapping-regeneration tooling depends on) without any per-scrape
+	// fabrication. Each scrape that finds the docappender scope updates
+	// the fields it observes; fields docappender never reports stay at
+	// 0; fields docappender stops reporting retain their last-known
+	// value rather than silently snapping back to a fabricated 0.
+	outputState := &libbeatOutputState{}
+	pipelineState := &libbeatPipelineState{}
+
 	monitoring.NewFunc(libbeatRegistry, "output", func(_ monitoring.Mode, v monitoring.Visitor) {
 		var rm metricdata.ResourceMetrics
 		if err := b.metricReader.Collect(context.Background(), &rm); err != nil {
 			return
 		}
-		v.OnRegistryStart()
-		defer v.OnRegistryFinished()
+		var docappenderSeen bool
 		for _, sm := range rm.ScopeMetrics {
-			switch {
-			case sm.Scope.Name == "github.com/elastic/go-docappender":
-				monitoring.ReportString(v, "type", "elasticsearch")
-				addDocappenderLibbeatOutputMetrics(context.Background(), v, sm)
+			if sm.Scope.Name == "github.com/elastic/go-docappender" {
+				docappenderSeen = true
+				outputState.update(sm)
 			}
 		}
+		v.OnRegistryStart()
+		defer v.OnRegistryFinished()
+		if !docappenderSeen && !outputState.everSeen() {
+			// Never observed docappender (e.g. console output): emit
+			// nothing so libbeat.output stays an empty sub-tree, the
+			// same shape /stats had before this PR.
+			return
+		}
+		monitoring.ReportString(v, "type", "elasticsearch")
+		outputState.report(v)
 	})
 	monitoring.NewFunc(libbeatRegistry, "pipeline", func(_ monitoring.Mode, v monitoring.Visitor) {
 		var rm metricdata.ResourceMetrics
 		if err := b.metricReader.Collect(context.Background(), &rm); err != nil {
 			return
 		}
-		v.OnRegistryStart()
-		defer v.OnRegistryFinished()
+		var docappenderSeen bool
 		for _, sm := range rm.ScopeMetrics {
-			switch {
-			case sm.Scope.Name == "github.com/elastic/go-docappender":
-				addDocappenderLibbeatPipelineMetrics(context.Background(), v, sm)
+			if sm.Scope.Name == "github.com/elastic/go-docappender" {
+				docappenderSeen = true
+				pipelineState.update(sm)
 			}
 		}
+		v.OnRegistryStart()
+		defer v.OnRegistryFinished()
+		if !docappenderSeen && !pipelineState.everSeen() {
+			return
+		}
+		pipelineState.report(v)
 	})
 	monitoring.NewFunc(statsRegistry, "output.elasticsearch", func(_ monitoring.Mode, v monitoring.Visitor) {
 		var rm metricdata.ResourceMetrics
@@ -651,13 +677,20 @@ func reportOnKey(v monitoring.Visitor, m map[string]any) {
 	}
 }
 
-// Adapt go-docappender's OTel metrics to beats stack monitoring metrics,
-// with a mixture of libbeat-specific and apm-server specific metric names.
-func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visitor, sm metricdata.ScopeMetrics) {
-	var writeBytes int64
+// libbeatOutputState holds the last observed values for the
+// libbeat.output.* sub-tree. Zero-initialised at process start so every
+// field appears in /stats from the first scrape, even before docappender
+// has reported anything; subsequent scrapes update only the fields
+// docappender currently exports, so a rename or drop in docappender does
+// not silently snap a field back to a fabricated 0 — the last-known
+// value is retained.
+type libbeatOutputState struct {
+	seen                                                       atomic.Bool
+	acked, active, batches, failed, toomany, total, writeBytes atomic.Int64
+}
 
-	v.OnRegistryStart()
-	v.OnKey("events")
+func (s *libbeatOutputState) update(sm metricdata.ScopeMetrics) {
+	s.seen.Store(true)
 	for _, m := range sm.Metrics {
 		switch m.Name {
 		case "elasticsearch.events.processed":
@@ -678,48 +711,78 @@ func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visito
 					failed += dp.Value
 				}
 			}
-			monitoring.ReportInt(v, "acked", acked)
-			monitoring.ReportInt(v, "failed", failed)
-			monitoring.ReportInt(v, "toomany", toomany)
+			s.acked.Store(acked)
+			s.toomany.Store(toomany)
+			s.failed.Store(failed)
 		case "elasticsearch.events.count":
 			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "total", value)
+				s.total.Store(value)
 			}
 		case "elasticsearch.events.queued":
 			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "active", value)
+				s.active.Store(value)
 			}
 		case "elasticsearch.flushed.bytes":
 			if value, ok := getScalarInt64(m.Data); ok {
-				writeBytes = value
+				s.writeBytes.Store(value)
 			}
 		case "elasticsearch.bulk_requests.count":
 			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "batches", value)
+				s.batches.Store(value)
 			}
 		}
 	}
+}
+
+func (s *libbeatOutputState) report(v monitoring.Visitor) {
+	v.OnRegistryStart()
+	v.OnKey("events")
+	monitoring.ReportInt(v, "acked", s.acked.Load())
+	monitoring.ReportInt(v, "active", s.active.Load())
+	monitoring.ReportInt(v, "batches", s.batches.Load())
+	monitoring.ReportInt(v, "failed", s.failed.Load())
+	monitoring.ReportInt(v, "toomany", s.toomany.Load())
+	monitoring.ReportInt(v, "total", s.total.Load())
 	v.OnRegistryFinished()
 
 	v.OnRegistryStart()
 	v.OnKey("write")
-	monitoring.ReportInt(v, "bytes", writeBytes)
+	monitoring.ReportInt(v, "bytes", s.writeBytes.Load())
 	v.OnRegistryFinished()
 }
 
-func addDocappenderLibbeatPipelineMetrics(ctx context.Context, v monitoring.Visitor, sm metricdata.ScopeMetrics) {
-	v.OnRegistryStart()
-	defer v.OnRegistryFinished()
-	v.OnKey("events")
+func (s *libbeatOutputState) everSeen() bool {
+	return s.seen.Load()
+}
 
+// libbeatPipelineState holds the last observed values for the
+// libbeat.pipeline.* sub-tree. Same shape and rationale as
+// libbeatOutputState.
+type libbeatPipelineState struct {
+	seen  atomic.Bool
+	total atomic.Int64
+}
+
+func (s *libbeatPipelineState) update(sm metricdata.ScopeMetrics) {
+	s.seen.Store(true)
 	for _, m := range sm.Metrics {
-		switch m.Name {
-		case "elasticsearch.events.count":
+		if m.Name == "elasticsearch.events.count" {
 			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "total", value)
+				s.total.Store(value)
 			}
 		}
 	}
+}
+
+func (s *libbeatPipelineState) report(v monitoring.Visitor) {
+	v.OnRegistryStart()
+	defer v.OnRegistryFinished()
+	v.OnKey("events")
+	monitoring.ReportInt(v, "total", s.total.Load())
+}
+
+func (s *libbeatPipelineState) everSeen() bool {
+	return s.seen.Load()
 }
 
 // Add non-libbeat Elasticsearch output metrics under "output.elasticsearch".

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -547,7 +547,7 @@ func (b *Beat) registerStatsMetrics() {
 			case strings.HasPrefix(sm.Scope.Name, "github.com/elastic/apm-server"):
 				// All simple scalar metrics that begin with the name "apm-server."
 				// in github.com/elastic/apm-server/... scopes are mapped directly.
-				addAPMServerMetricsToMap(beatsMetrics, sm.Metrics)
+				addAPMServerMetricsToMap(beatsMetrics, sm.Metrics, b.Info.Logger)
 			}
 		}
 
@@ -597,7 +597,7 @@ func getScalarFloat64(data metricdata.Aggregation) (float64, bool) {
 
 // addAPMServerMetricsToMap adds simple scalar metrics with the "apm-server." prefix
 // to the map. Both int64 and float64 instruments are supported.
-func addAPMServerMetricsToMap(beatsMetrics map[string]any, metrics []metricdata.Metrics) {
+func addAPMServerMetricsToMap(beatsMetrics map[string]any, metrics []metricdata.Metrics, logger *logp.Logger) {
 	for _, m := range metrics {
 		suffix, ok := strings.CutPrefix(m.Name, "apm-server.")
 		if !ok {
@@ -609,6 +609,10 @@ func addAPMServerMetricsToMap(beatsMetrics map[string]any, metrics []metricdata.
 		} else if v, ok := getScalarFloat64(m.Data); ok {
 			value = v
 		} else {
+			logger.With(
+				"name", m.Name,
+				"type", fmt.Sprintf("%T", m.Data),
+			).Error("BUG: cannot report monitoring metric")
 			continue
 		}
 		current := beatsMetrics

--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -651,17 +651,17 @@ func reportOnKey(v monitoring.Visitor, m map[string]any) {
 	}
 }
 
-// Adapt go-docappender's OTel metrics to beats stack monitoring metrics,
-// with a mixture of libbeat-specific and apm-server specific metric names.
+// addDocappenderLibbeatOutputMetrics adapts go-docappender's OTel metrics to
+// the libbeat.output.* monitoring tree. Every reported field is accumulated
+// into a local variable and reported unconditionally, so the full field set
+// appears with zero values even before docappender has published anything.
+// This keeps /stats's libbeat.output.* shape stable from process start, which
+// downstream mapping-regeneration tooling relies on.
 func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visitor, sm metricdata.ScopeMetrics) {
-	var writeBytes int64
-
-	v.OnRegistryStart()
-	v.OnKey("events")
+	var acked, active, batches, failed, toomany, total, writeBytes int64
 	for _, m := range sm.Metrics {
 		switch m.Name {
 		case "elasticsearch.events.processed":
-			var acked, toomany, failed int64
 			data, _ := m.Data.(metricdata.Sum[int64])
 			for _, dp := range data.DataPoints {
 				status, ok := dp.Attributes.Value(attribute.Key("status"))
@@ -678,16 +678,13 @@ func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visito
 					failed += dp.Value
 				}
 			}
-			monitoring.ReportInt(v, "acked", acked)
-			monitoring.ReportInt(v, "failed", failed)
-			monitoring.ReportInt(v, "toomany", toomany)
 		case "elasticsearch.events.count":
 			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "total", value)
+				total = value
 			}
 		case "elasticsearch.events.queued":
 			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "active", value)
+				active = value
 			}
 		case "elasticsearch.flushed.bytes":
 			if value, ok := getScalarInt64(m.Data); ok {
@@ -695,33 +692,45 @@ func addDocappenderLibbeatOutputMetrics(ctx context.Context, v monitoring.Visito
 			}
 		case "elasticsearch.bulk_requests.count":
 			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "batches", value)
+				batches = value
 			}
 		}
 	}
+
+	v.OnRegistryStart()
+	v.OnKey("events")
+	monitoring.ReportInt(v, "acked", acked)
+	monitoring.ReportInt(v, "active", active)
+	monitoring.ReportInt(v, "batches", batches)
+	monitoring.ReportInt(v, "failed", failed)
+	monitoring.ReportInt(v, "toomany", toomany)
+	monitoring.ReportInt(v, "total", total)
 	v.OnRegistryFinished()
 
-	if writeBytes > 0 {
-		v.OnRegistryStart()
-		v.OnKey("write")
-		monitoring.ReportInt(v, "bytes", writeBytes)
-		v.OnRegistryFinished()
-	}
+	v.OnRegistryStart()
+	v.OnKey("write")
+	monitoring.ReportInt(v, "bytes", writeBytes)
+	v.OnRegistryFinished()
 }
 
+// addDocappenderLibbeatPipelineMetrics adapts go-docappender's OTel metrics
+// to the libbeat.pipeline.* monitoring tree. Reports the field unconditionally
+// so it surfaces at zero before any publish, matching the eager-emission
+// contract used by addDocappenderLibbeatOutputMetrics.
 func addDocappenderLibbeatPipelineMetrics(ctx context.Context, v monitoring.Visitor, sm metricdata.ScopeMetrics) {
+	var total int64
+	for _, m := range sm.Metrics {
+		if m.Name == "elasticsearch.events.count" {
+			if value, ok := getScalarInt64(m.Data); ok {
+				total = value
+			}
+		}
+	}
+
 	v.OnRegistryStart()
 	defer v.OnRegistryFinished()
 	v.OnKey("events")
-
-	for _, m := range sm.Metrics {
-		switch m.Name {
-		case "elasticsearch.events.count":
-			if value, ok := getScalarInt64(m.Data); ok {
-				monitoring.ReportInt(v, "total", value)
-			}
-		}
-	}
+	monitoring.ReportInt(v, "total", total)
 }
 
 // Add non-libbeat Elasticsearch output metrics under "output.elasticsearch".

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -170,15 +170,8 @@ func TestLibbeatMetrics(t *testing.T) {
 		"output": map[string]any{
 			"type": "elasticsearch",
 			"events": map[string]any{
-				"acked":   int64(0),
-				"active":  int64(totalRequests),
-				"batches": int64(0),
-				"failed":  int64(0),
-				"toomany": int64(0),
-				"total":   int64(totalRequests),
-			},
-			"write": map[string]any{
-				"bytes": int64(0),
+				"active": int64(totalRequests),
+				"total":  int64(totalRequests),
 			},
 		},
 		"pipeline": map[string]any{
@@ -237,61 +230,6 @@ func TestLibbeatMetrics(t *testing.T) {
 				"active":    int64(2),
 				"created":   int64(1),
 				"destroyed": int64(0),
-			},
-		},
-	}, snapshot)
-}
-
-// TestLibbeatMetricsEagerZero verifies that the libbeat.output.* and
-// libbeat.pipeline.* fields populated by the docappender adapters are
-// present at zero before any indexing has occurred. The mapping-regeneration
-// tooling reads a single /stats snapshot, so every field that may appear
-// later must already exist at startup.
-func TestLibbeatMetricsEagerZero(t *testing.T) {
-	runnerParamsChan := make(chan RunnerParams, 1)
-	beat := newBeat(t, "output.elasticsearch.enabled: true", func(args RunnerParams) (Runner, error) {
-		runnerParamsChan <- args
-		return runnerFunc(func(ctx context.Context) error {
-			<-ctx.Done()
-			return ctx.Err()
-		}), nil
-	})
-	stop := runBeat(t, beat)
-	defer func() { assert.NoError(t, stop()) }()
-	args := <-runnerParamsChan
-
-	esClient := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected request to mock ES")
-	})
-	appender, err := docappender.New(esClient, docappender.Config{
-		MeterProvider: args.MeterProvider,
-	})
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, appender.Close(context.Background()))
-	}()
-
-	statsRegistry := beat.Monitoring.StatsRegistry()
-	libbeatRegistry := statsRegistry.GetRegistry("libbeat")
-	snapshot := monitoring.CollectStructSnapshot(libbeatRegistry, monitoring.Full, false)
-	assert.Equal(t, map[string]any{
-		"output": map[string]any{
-			"type": "elasticsearch",
-			"events": map[string]any{
-				"acked":   int64(0),
-				"active":  int64(0),
-				"batches": int64(0),
-				"failed":  int64(0),
-				"toomany": int64(0),
-				"total":   int64(0),
-			},
-			"write": map[string]any{
-				"bytes": int64(0),
-			},
-		},
-		"pipeline": map[string]any{
-			"events": map[string]any{
-				"total": int64(0),
 			},
 		},
 	}, snapshot)

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -285,17 +285,19 @@ func TestMonitoringApmServer(t *testing.T) {
 	b := newNopBeat(t, "")
 	b.registerStatsMetrics()
 
-	// add metrics similar to lsm_size in storage_manager.go and events.processed in processor.go
-	meter := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage")
-	lsmSizeGauge, _ := meter.Int64Gauge("apm-server.sampling.tail.storage.lsm_size")
+	// Three independently-scoped meters whose metrics share the
+	// "apm-server.sampling" prefix; the assertion below verifies they
+	// merge into one snapshot subtree.
+	storageMeter := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage")
+	lsmSizeGauge, _ := storageMeter.Int64Gauge("apm-server.sampling.tail.storage.lsm_size")
 	lsmSizeGauge.Record(context.Background(), 123)
 
-	meter2 := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/sampling")
-	processedCounter, _ := meter2.Int64Counter("apm-server.sampling.tail.events.processed")
+	samplingMeter := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/sampling")
+	processedCounter, _ := samplingMeter.Int64Counter("apm-server.sampling.tail.events.processed")
 	processedCounter.Add(context.Background(), 456)
 
-	meter3 := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/foo")
-	otherCounter, _ := meter3.Int64Counter("apm-server.sampling.foo.request")
+	otherSamplingMeter := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/foo")
+	otherCounter, _ := otherSamplingMeter.Int64Counter("apm-server.sampling.foo.request")
 	otherCounter.Add(context.Background(), 1)
 
 	// collect metrics

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -268,7 +268,7 @@ func TestAddAPMServerMetrics(t *testing.T) {
 		defer v.OnRegistryFinished()
 
 		beatsMetrics := make(map[string]any)
-		addAPMServerMetricsToMap(beatsMetrics, sm.Metrics)
+		addAPMServerMetricsToMap(beatsMetrics, sm.Metrics, logptest.NewTestingLogger(t, "beat"))
 		reportOnKey(v, beatsMetrics)
 	})
 
@@ -750,6 +750,31 @@ func (m *mockManager) SetStopCallback(f func()) {
 	m.stopCallback = f
 }
 
+func TestAddAPMServerMetricsToMapBUG(t *testing.T) {
+	// A Histogram is not in the {Sum,Gauge}[int64,float64] set the
+	// translator handles; addAPMServerMetricsToMap should drop it from
+	// the output and log the BUG with the metric's name and Go type.
+	logger, observed := logptest.NewTestingLoggerWithObserver(t, "beat")
+
+	metrics := []metricdata.Metrics{{
+		Name: "apm-server.unsupported.metric",
+		Data: metricdata.Histogram[int64]{
+			DataPoints: []metricdata.HistogramDataPoint[int64]{{Count: 1}},
+		},
+	}}
+
+	out := map[string]any{}
+	addAPMServerMetricsToMap(out, metrics, logger)
+
+	assert.Empty(t, out)
+
+	entries := observed.FilterMessage("BUG: cannot report monitoring metric").All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	assert.Equal(t, "apm-server.unsupported.metric", fields["name"])
+	assert.Contains(t, fields["type"], "Histogram")
+}
+
 func BenchmarkAddAPMServerMetricsToMap(b *testing.B) {
 	int64Sum := metricdata.Sum[int64]{
 		DataPoints: []metricdata.DataPoint[int64]{{Value: 1}},
@@ -762,8 +787,9 @@ func BenchmarkAddAPMServerMetricsToMap(b *testing.B) {
 		{Name: "apm-server.sampling.tail.events.processed", Data: int64Sum},
 		{Name: "apm-server.sampling.tail.storage.disk_usage_threshold_pct", Data: float64Gauge},
 	}
+	logger := logptest.NewTestingLogger(b, "beat")
 	b.ReportAllocs()
 	for b.Loop() {
-		addAPMServerMetricsToMap(map[string]any{}, metrics)
+		addAPMServerMetricsToMap(map[string]any{}, metrics, logger)
 	}
 }

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -170,8 +170,15 @@ func TestLibbeatMetrics(t *testing.T) {
 		"output": map[string]any{
 			"type": "elasticsearch",
 			"events": map[string]any{
-				"active": int64(totalRequests),
-				"total":  int64(totalRequests),
+				"acked":   int64(0),
+				"active":  int64(totalRequests),
+				"batches": int64(0),
+				"failed":  int64(0),
+				"toomany": int64(0),
+				"total":   int64(totalRequests),
+			},
+			"write": map[string]any{
+				"bytes": int64(0),
 			},
 		},
 		"pipeline": map[string]any{
@@ -230,6 +237,61 @@ func TestLibbeatMetrics(t *testing.T) {
 				"active":    int64(2),
 				"created":   int64(1),
 				"destroyed": int64(0),
+			},
+		},
+	}, snapshot)
+}
+
+// TestLibbeatMetricsEagerZero verifies that the libbeat.output.* and
+// libbeat.pipeline.* fields populated by the docappender adapters are
+// present at zero before any indexing has occurred. The mapping-regeneration
+// tooling reads a single /stats snapshot, so every field that may appear
+// later must already exist at startup.
+func TestLibbeatMetricsEagerZero(t *testing.T) {
+	runnerParamsChan := make(chan RunnerParams, 1)
+	beat := newBeat(t, "output.elasticsearch.enabled: true", func(args RunnerParams) (Runner, error) {
+		runnerParamsChan <- args
+		return runnerFunc(func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}), nil
+	})
+	stop := runBeat(t, beat)
+	defer func() { assert.NoError(t, stop()) }()
+	args := <-runnerParamsChan
+
+	esClient := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request to mock ES")
+	})
+	appender, err := docappender.New(esClient, docappender.Config{
+		MeterProvider: args.MeterProvider,
+	})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, appender.Close(context.Background()))
+	}()
+
+	statsRegistry := beat.Monitoring.StatsRegistry()
+	libbeatRegistry := statsRegistry.GetRegistry("libbeat")
+	snapshot := monitoring.CollectStructSnapshot(libbeatRegistry, monitoring.Full, false)
+	assert.Equal(t, map[string]any{
+		"output": map[string]any{
+			"type": "elasticsearch",
+			"events": map[string]any{
+				"acked":   int64(0),
+				"active":  int64(0),
+				"batches": int64(0),
+				"failed":  int64(0),
+				"toomany": int64(0),
+				"total":   int64(0),
+			},
+			"write": map[string]any{
+				"bytes": int64(0),
+			},
+		},
+		"pipeline": map[string]any{
+			"events": map[string]any{
+				"total": int64(0),
 			},
 		},
 	}, snapshot)

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -749,3 +749,21 @@ func (m *mockManager) Stop() {
 func (m *mockManager) SetStopCallback(f func()) {
 	m.stopCallback = f
 }
+
+func BenchmarkAddAPMServerMetricsToMap(b *testing.B) {
+	int64Sum := metricdata.Sum[int64]{
+		DataPoints: []metricdata.DataPoint[int64]{{Value: 1}},
+	}
+	float64Gauge := metricdata.Gauge[float64]{
+		DataPoints: []metricdata.DataPoint[float64]{{Value: 0.8}},
+	}
+	metrics := []metricdata.Metrics{
+		{Name: "apm-server.acm.response.errors.count", Data: int64Sum},
+		{Name: "apm-server.sampling.tail.events.processed", Data: int64Sum},
+		{Name: "apm-server.sampling.tail.storage.disk_usage_threshold_pct", Data: float64Gauge},
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		addAPMServerMetricsToMap(map[string]any{}, metrics)
+	}
+}

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -291,6 +291,10 @@ func TestMonitoringApmServer(t *testing.T) {
 	storageMeter := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage")
 	lsmSizeGauge, _ := storageMeter.Int64Gauge("apm-server.sampling.tail.storage.lsm_size")
 	lsmSizeGauge.Record(context.Background(), 123)
+	// Float-typed instruments under apm-server.* must surface in the
+	// snapshot too, not only int64 ones.
+	diskThresholdGauge, _ := storageMeter.Float64Gauge("apm-server.sampling.tail.storage.disk_usage_threshold_pct")
+	diskThresholdGauge.Record(context.Background(), 0.8)
 
 	samplingMeter := b.meterProvider.Meter("github.com/elastic/apm-server/x-pack/apm-server/sampling")
 	processedCounter, _ := samplingMeter.Int64Counter("apm-server.sampling.tail.events.processed")
@@ -313,7 +317,8 @@ func TestMonitoringApmServer(t *testing.T) {
 				},
 				"tail": map[string]any{
 					"storage": map[string]any{
-						"lsm_size": int64(123),
+						"lsm_size":                 int64(123),
+						"disk_usage_threshold_pct": 0.8,
 					},
 					"events": map[string]any{
 						"processed": int64(456),

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -235,6 +235,64 @@ func TestLibbeatMetrics(t *testing.T) {
 	}, snapshot)
 }
 
+// TestLibbeatMetricsEagerZero confirms that the docappender-derived
+// libbeat.output.* / libbeat.pipeline.* fields surface in /stats from
+// process start, before any indexing has occurred. Five of these fields
+// are unblocked by the upstream Add(0) eager-init in
+// https://github.com/elastic/go-docappender/pull/317; the three
+// status-attributed fields (events.acked / events.failed / events.toomany,
+// derived from elasticsearch.events.processed) remain lazy until a
+// follow-up addresses status-attributed counters.
+//
+// The test is skipped until apm-server's docappender go.mod entry is
+// bumped to a release that includes the eager-init change. It can be
+// validated locally before that release lands by adding a `replace`
+// directive in go.mod pointing at a local docappender checkout on the
+// PR branch.
+func TestLibbeatMetricsEagerZero(t *testing.T) {
+	t.Skip("requires elastic/go-docappender#317; remove this skip after the docappender bump")
+
+	runnerParamsChan := make(chan RunnerParams, 1)
+	beat := newBeat(t, "output.elasticsearch.enabled: true", func(args RunnerParams) (Runner, error) {
+		runnerParamsChan <- args
+		return runnerFunc(func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}), nil
+	})
+	stop := runBeat(t, beat)
+	defer func() { assert.NoError(t, stop()) }()
+	args := <-runnerParamsChan
+
+	esClient := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request to mock ES")
+	})
+	appender, err := docappender.New(esClient, docappender.Config{
+		MeterProvider: args.MeterProvider,
+	})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, appender.Close(context.Background()))
+	}()
+
+	statsRegistry := beat.Monitoring.StatsRegistry()
+	libbeatRegistry := statsRegistry.GetRegistry("libbeat")
+	snapshot := monitoring.CollectStructSnapshot(libbeatRegistry, monitoring.Full, false)
+
+	output := snapshot["output"].(map[string]any)
+	assert.Equal(t, "elasticsearch", output["type"])
+	events := output["events"].(map[string]any)
+	assert.Equal(t, int64(0), events["active"])
+	assert.Equal(t, int64(0), events["batches"])
+	assert.Equal(t, int64(0), events["total"])
+	write := output["write"].(map[string]any)
+	assert.Equal(t, int64(0), write["bytes"])
+
+	pipeline := snapshot["pipeline"].(map[string]any)
+	pipelineEvents := pipeline["events"].(map[string]any)
+	assert.Equal(t, int64(0), pipelineEvents["total"])
+}
+
 // TestAddAPMServerMetrics tests basic functionality of the metrics collection and reporting
 func TestAddAPMServerMetrics(t *testing.T) {
 	r := monitoring.NewRegistry()

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -173,6 +173,9 @@ func TestLibbeatMetrics(t *testing.T) {
 				"active": int64(totalRequests),
 				"total":  int64(totalRequests),
 			},
+			"write": map[string]any{
+				"bytes": int64(0),
+			},
 		},
 		"pipeline": map[string]any{
 			"events": map[string]any{

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -170,8 +170,12 @@ func TestLibbeatMetrics(t *testing.T) {
 		"output": map[string]any{
 			"type": "elasticsearch",
 			"events": map[string]any{
-				"active": int64(totalRequests),
-				"total":  int64(totalRequests),
+				"acked":   int64(0),
+				"active":  int64(totalRequests),
+				"batches": int64(0),
+				"failed":  int64(0),
+				"toomany": int64(0),
+				"total":   int64(totalRequests),
 			},
 			"write": map[string]any{
 				"bytes": int64(0),
@@ -238,23 +242,13 @@ func TestLibbeatMetrics(t *testing.T) {
 	}, snapshot)
 }
 
-// TestLibbeatMetricsEagerZero confirms that the docappender-derived
-// libbeat.output.* / libbeat.pipeline.* fields surface in /stats from
-// process start, before any indexing has occurred. Five of these fields
-// are unblocked by the upstream Add(0) eager-init in
-// https://github.com/elastic/go-docappender/pull/317; the three
-// status-attributed fields (events.acked / events.failed / events.toomany,
-// derived from elasticsearch.events.processed) remain lazy until a
-// follow-up addresses status-attributed counters.
-//
-// The test is skipped until apm-server's docappender go.mod entry is
-// bumped to a release that includes the eager-init change. It can be
-// validated locally before that release lands by adding a `replace`
-// directive in go.mod pointing at a local docappender checkout on the
-// PR branch.
+// TestLibbeatMetricsEagerZero confirms that every docappender-derived
+// libbeat.output.* / libbeat.pipeline.* field surfaces in /stats from
+// process start, before any indexing has occurred. The apm-server-side
+// adapters in addDocappenderLibbeat{Output,Pipeline}Metrics own this
+// schema and emit zero values unconditionally; this test locks the
+// contract that downstream mapping-regeneration tooling depends on.
 func TestLibbeatMetricsEagerZero(t *testing.T) {
-	t.Skip("requires elastic/go-docappender#317; remove this skip after the docappender bump")
-
 	runnerParamsChan := make(chan RunnerParams, 1)
 	beat := newBeat(t, "output.elasticsearch.enabled: true", func(args RunnerParams) (Runner, error) {
 		runnerParamsChan <- args
@@ -281,19 +275,27 @@ func TestLibbeatMetricsEagerZero(t *testing.T) {
 	statsRegistry := beat.Monitoring.StatsRegistry()
 	libbeatRegistry := statsRegistry.GetRegistry("libbeat")
 	snapshot := monitoring.CollectStructSnapshot(libbeatRegistry, monitoring.Full, false)
-
-	output := snapshot["output"].(map[string]any)
-	assert.Equal(t, "elasticsearch", output["type"])
-	events := output["events"].(map[string]any)
-	assert.Equal(t, int64(0), events["active"])
-	assert.Equal(t, int64(0), events["batches"])
-	assert.Equal(t, int64(0), events["total"])
-	write := output["write"].(map[string]any)
-	assert.Equal(t, int64(0), write["bytes"])
-
-	pipeline := snapshot["pipeline"].(map[string]any)
-	pipelineEvents := pipeline["events"].(map[string]any)
-	assert.Equal(t, int64(0), pipelineEvents["total"])
+	assert.Equal(t, map[string]any{
+		"output": map[string]any{
+			"type": "elasticsearch",
+			"events": map[string]any{
+				"acked":   int64(0),
+				"active":  int64(0),
+				"batches": int64(0),
+				"failed":  int64(0),
+				"toomany": int64(0),
+				"total":   int64(0),
+			},
+			"write": map[string]any{
+				"bytes": int64(0),
+			},
+		},
+		"pipeline": map[string]any{
+			"events": map[string]any{
+				"total": int64(0),
+			},
+		},
+	}, snapshot)
 }
 
 // TestAddAPMServerMetrics tests basic functionality of the metrics collection and reporting

--- a/internal/beater/api/intake/handler.go
+++ b/internal/beater/api/intake/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/apm-server/internal/beater/headers"
 	"github.com/elastic/apm-server/internal/beater/ratelimit"
 	"github.com/elastic/apm-server/internal/beater/request"
+	"github.com/elastic/apm-server/internal/otelmetric"
 	"github.com/elastic/apm-server/internal/publish"
 )
 
@@ -55,9 +56,9 @@ type RequestMetadataFunc func(*request.Context) *modelpb.APMEvent
 // Handler returns a request.Handler for managing intake requests for backend and rum events.
 func Handler(mp metric.MeterProvider, tp trace.TracerProvider, handler elasticapm.StreamHandler, requestMetadataFunc RequestMetadataFunc, batchProcessor modelpb.BatchProcessor) request.Handler {
 	meter := mp.Meter("github.com/elastic/apm-server/internal/beater/api/intake")
-	eventsAccepted, _ := meter.Int64Counter("apm-server.processor.stream.accepted")
-	eventsInvalid, _ := meter.Int64Counter("apm-server.processor.stream.errors.invalid")
-	eventsTooLarge, _ := meter.Int64Counter("apm-server.processor.stream.errors.toolarge")
+	eventsAccepted := otelmetric.NewInt64Counter(meter, "apm-server.processor.stream.accepted")
+	eventsInvalid := otelmetric.NewInt64Counter(meter, "apm-server.processor.stream.errors.invalid")
+	eventsTooLarge := otelmetric.NewInt64Counter(meter, "apm-server.processor.stream.errors.toolarge")
 
 	batchProcessor = modelprocessor.NewTracer("intake.ProcessBatch", batchProcessor, modelprocessor.WithTracerProvider(tp))
 

--- a/internal/beater/api/mux.go
+++ b/internal/beater/api/mux.go
@@ -269,7 +269,7 @@ func apmMiddleware(mp metric.MeterProvider, tp trace.TracerProvider, metricsPref
 		middleware.TracingMiddleware(tp),
 		middleware.LogMiddleware(logger),
 		middleware.RecoverPanicMiddleware(),
-		middleware.MonitoringMiddleware(metricsPrefix, mp),
+		middleware.MonitoringMiddleware(metricsPrefix, mp, logger),
 	}
 }
 

--- a/internal/beater/api/mux_config_agent_test.go
+++ b/internal/beater/api/mux_config_agent_test.go
@@ -61,10 +61,14 @@ func TestConfigAgentHandler_PanicMiddleware(t *testing.T) {
 
 func TestConfigAgentHandler_MonitoringMiddleware(t *testing.T) {
 	testMonitoringMiddleware(t, "/config/v1/agents", map[string]any{
-		"http.server." + string(request.IDRequestCount):               1,
-		"http.server." + string(request.IDResponseCount):              1,
-		"http.server." + string(request.IDResponseErrorsCount):        1,
-		"http.server." + string(request.IDResponseErrorsInvalidQuery): 1,
+		"http.server." + string(request.IDRequestCount):                  1,
+		"http.server." + string(request.IDResponseCount):                 1,
+		"http.server." + string(request.IDResponseErrorsCount):           1,
+		"http.server." + string(request.IDResponseErrorsInvalidQuery):    1,
+		"apm-server.acm." + string(request.IDRequestCount):               1,
+		"apm-server.acm." + string(request.IDResponseCount):              1,
+		"apm-server.acm." + string(request.IDResponseErrorsCount):        1,
+		"apm-server.acm." + string(request.IDResponseErrorsInvalidQuery): 1,
 	})
 }
 

--- a/internal/beater/api/mux_intake_backend_test.go
+++ b/internal/beater/api/mux_intake_backend_test.go
@@ -66,10 +66,14 @@ func TestIntakeBackendHandler_PanicMiddleware(t *testing.T) {
 func TestIntakeBackendHandler_MonitoringMiddleware(t *testing.T) {
 	// send GET request resulting in 405 MethodNotAllowed error
 	testMonitoringMiddleware(t, "/intake/v2/events", map[string]any{
-		"http.server." + string(request.IDRequestCount):                   1,
-		"http.server." + string(request.IDResponseCount):                  1,
-		"http.server." + string(request.IDResponseErrorsCount):            1,
-		"http.server." + string(request.IDResponseErrorsMethodNotAllowed): 1,
+		"http.server." + string(request.IDRequestCount):                         1,
+		"http.server." + string(request.IDResponseCount):                        1,
+		"http.server." + string(request.IDResponseErrorsCount):                  1,
+		"http.server." + string(request.IDResponseErrorsMethodNotAllowed):       1,
+		"apm-server.server." + string(request.IDRequestCount):                   1,
+		"apm-server.server." + string(request.IDResponseCount):                  1,
+		"apm-server.server." + string(request.IDResponseErrorsCount):            1,
+		"apm-server.server." + string(request.IDResponseErrorsMethodNotAllowed): 1,
 	})
 }
 

--- a/internal/beater/api/mux_intake_rum_test.go
+++ b/internal/beater/api/mux_intake_rum_test.go
@@ -132,10 +132,14 @@ func TestRumHandler_MonitoringMiddleware(t *testing.T) {
 	// send GET request resulting in 403 Forbidden error
 	for _, path := range []string{"/intake/v2/rum/events", "/intake/v3/rum/events"} {
 		testMonitoringMiddleware(t, path, map[string]any{
-			"http.server." + string(request.IDRequestCount):            1,
-			"http.server." + string(request.IDResponseCount):           1,
-			"http.server." + string(request.IDResponseErrorsCount):     1,
-			"http.server." + string(request.IDResponseErrorsForbidden): 1,
+			"http.server." + string(request.IDRequestCount):                  1,
+			"http.server." + string(request.IDResponseCount):                 1,
+			"http.server." + string(request.IDResponseErrorsCount):           1,
+			"http.server." + string(request.IDResponseErrorsForbidden):       1,
+			"apm-server.server." + string(request.IDRequestCount):            1,
+			"apm-server.server." + string(request.IDResponseCount):           1,
+			"apm-server.server." + string(request.IDResponseErrorsCount):     1,
+			"apm-server.server." + string(request.IDResponseErrorsForbidden): 1,
 		})
 	}
 }

--- a/internal/beater/api/mux_root_test.go
+++ b/internal/beater/api/mux_root_test.go
@@ -111,7 +111,7 @@ func TestRootHandler_MonitoringMiddleware(t *testing.T) {
 			req := httptest.NewRequest(tc.method, "/", nil)
 			h.ServeHTTP(httptest.NewRecorder(), req)
 
-			monitoringtest.ExpectContainOtelMetrics(t, reader, tc.wantMetrics)
+			monitoringtest.ExpectOtelMetrics(t, reader, tc.wantMetrics)
 		})
 	}
 }

--- a/internal/beater/api/mux_root_test.go
+++ b/internal/beater/api/mux_root_test.go
@@ -111,7 +111,7 @@ func TestRootHandler_MonitoringMiddleware(t *testing.T) {
 			req := httptest.NewRequest(tc.method, "/", nil)
 			h.ServeHTTP(httptest.NewRecorder(), req)
 
-			monitoringtest.ExpectOtelMetrics(t, reader, tc.wantMetrics)
+			monitoringtest.ExpectOtelMetricsNonZero(t, reader, tc.wantMetrics)
 		})
 	}
 }

--- a/internal/beater/api/mux_root_test.go
+++ b/internal/beater/api/mux_root_test.go
@@ -111,7 +111,7 @@ func TestRootHandler_MonitoringMiddleware(t *testing.T) {
 			req := httptest.NewRequest(tc.method, "/", nil)
 			h.ServeHTTP(httptest.NewRecorder(), req)
 
-			monitoringtest.ExpectOtelMetricsNonZero(t, reader, tc.wantMetrics)
+			monitoringtest.ExpectContainOtelMetrics(t, reader, tc.wantMetrics)
 		})
 	}
 }

--- a/internal/beater/api/mux_test.go
+++ b/internal/beater/api/mux_test.go
@@ -148,10 +148,9 @@ func testMonitoringMiddleware(t *testing.T, urlPath string, expectedMetrics map[
 
 	// The full mux eagerly initializes counters across many prefixes
 	// (every MonitoringMiddleware instance plus the gRPC interceptor,
-	// intake handler, sampling, agentcfg, …). Use the non-zero
-	// assertion so the test only spells out the counters it cares
-	// about; the eager-init noise floor is verified to remain zero.
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, expectedMetrics)
+	// intake handler, sampling, agentcfg, …). Subset semantics keep
+	// the test focused on this handler's counters.
+	monitoringtest.ExpectContainOtelMetrics(t, reader, expectedMetrics)
 }
 
 func newTestMux(t *testing.T, cfg *config.Config) (http.Handler, sdkmetric.Reader) {

--- a/internal/beater/api/mux_test.go
+++ b/internal/beater/api/mux_test.go
@@ -146,7 +146,12 @@ func testMonitoringMiddleware(t *testing.T, urlPath string, expectedMetrics map[
 	req := httptest.NewRequest(http.MethodGet, urlPath, nil)
 	h.ServeHTTP(httptest.NewRecorder(), req)
 
-	monitoringtest.ExpectOtelMetrics(t, reader, expectedMetrics)
+	// The full mux eagerly initializes counters across many prefixes
+	// (every MonitoringMiddleware instance plus the gRPC interceptor,
+	// intake handler, sampling, agentcfg, …). Use the non-zero
+	// assertion so the test only spells out the counters it cares
+	// about; the eager-init noise floor is verified to remain zero.
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, expectedMetrics)
 }
 
 func newTestMux(t *testing.T, cfg *config.Config) (http.Handler, sdkmetric.Reader) {

--- a/internal/beater/api/mux_test.go
+++ b/internal/beater/api/mux_test.go
@@ -146,7 +146,7 @@ func testMonitoringMiddleware(t *testing.T, urlPath string, expectedMetrics map[
 	req := httptest.NewRequest(http.MethodGet, urlPath, nil)
 	h.ServeHTTP(httptest.NewRecorder(), req)
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, expectedMetrics)
+	monitoringtest.ExpectOtelMetrics(t, reader, expectedMetrics)
 }
 
 func newTestMux(t *testing.T, cfg *config.Config) (http.Handler, sdkmetric.Reader) {

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -73,6 +73,7 @@ import (
 	"github.com/elastic/apm-server/internal/fips140"
 	"github.com/elastic/apm-server/internal/kibana"
 	srvmodelprocessor "github.com/elastic/apm-server/internal/model/modelprocessor"
+	"github.com/elastic/apm-server/internal/otelmetric"
 	"github.com/elastic/apm-server/internal/publish"
 	"github.com/elastic/apm-server/internal/sourcemap"
 	"github.com/elastic/apm-server/internal/version"
@@ -406,10 +407,7 @@ func (s *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	transactionsDroppedCounter, err := meter.Int64Counter("apm-server.sampling.transactions_dropped")
-	if err != nil {
-		return err
-	}
+	transactionsDroppedCounter := otelmetric.NewInt64Counter(meter, "apm-server.sampling.transactions_dropped")
 	batchProcessor := modelprocessor.Chained{
 		// Ensure all events have observer.*, ecs.*, and data_stream.* fields added,
 		// and are counted in metrics. This is done in the final processors to ensure

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/elastic/apm-server/internal/beater/request"
+	"github.com/elastic/apm-server/internal/otelmetric"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -103,8 +104,7 @@ func (m *metricsInterceptor) getCounter(prefix, n string) metric.Int64Counter {
 	if met, ok := m.counters.Load(name); ok {
 		return met.(metric.Int64Counter)
 	}
-
-	nm, _ := m.meter.Int64Counter(name)
+	nm := otelmetric.NewInt64Counter(m.meter, name)
 	met, _ := m.counters.LoadOrStore(name, nm)
 	return met.(metric.Int64Counter)
 }
@@ -117,6 +117,15 @@ func (m *metricsInterceptor) getHistogram(n string, opts ...metric.Int64Histogra
 	nm, _ := m.meter.Int64Histogram(name, opts...)
 	met, _ := m.histograms.LoadOrStore(name, nm)
 	return met.(metric.Int64Histogram)
+}
+
+// otlpLegacyMetricsPrefixes lists every legacy metric prefix the metrics
+// interceptor records under. Used to eagerly register counters at startup
+// so /stats enumerates each metric from process start.
+var otlpLegacyMetricsPrefixes = []string{
+	"apm-server.otlp.grpc.metrics.",
+	"apm-server.otlp.grpc.traces.",
+	"apm-server.otlp.grpc.logs.",
 }
 
 // Metrics returns a grpc.UnaryServerInterceptor that increments metrics
@@ -136,6 +145,13 @@ func Metrics(logger *logp.Logger, mp metric.MeterProvider) grpc.UnaryServerInter
 
 		counters:   sync.Map{},
 		histograms: sync.Map{},
+	}
+
+	for _, id := range request.AllResultIDs {
+		i.getCounter("grpc.server.", string(id))
+		for _, prefix := range otlpLegacyMetricsPrefixes {
+			i.getCounter(prefix, string(id))
+		}
 	}
 
 	return i.Interceptor()

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -46,34 +46,25 @@ var otlpGRPCLegacyMetricsPrefixes = map[string]string{
 	"/opentelemetry.proto.collector.logs.v1.LogsService/Export":       "apm-server.otlp.grpc.logs.",
 }
 
-// counterKey identifies a counter by its (prefix, ResultID) tuple. Used as
-// the map key in metricsInterceptor.counters; struct keys avoid the
-// per-call allocation of "prefix + id" string concatenation.
+// counterKey is the map key for metricsInterceptor.counters. A struct key
+// is used instead of the concatenated "prefix+id" string so the lookup at
+// each m.inc() call avoids allocating a fresh string.
 type counterKey struct {
 	prefix string
 	id     request.ResultID
 }
 
 type metricsInterceptor struct {
-	logger *logp.Logger
-
-	// counters holds every counter the interceptor will ever record
-	// against. Populated once in Metrics() before the interceptor is
-	// returned; read-only thereafter, which makes plain map access safe
-	// for concurrent reads. Lookup misses are reported via logger and
-	// otherwise treated as no-ops; see the drift contract.
+	logger              *logp.Logger
 	counters            map[counterKey]metric.Int64Counter
 	requestDurationHist metric.Int64Histogram
 }
 
-// Drift contract: every prefix the inner closure passes to m.inc() comes
-// from otlpGRPCLegacyMetricsPrefixes (via the lookup below); every
-// request.ResultID it passes must appear in request.AllResultIDs. The
-// eager-registration loop in Metrics() iterates the cross-product of
-// those two sets and pre-populates m.counters. Any (prefix, id) pair the
-// inner closure tries to use that wasn't pre-populated is reported via
-// logger.Error and otherwise dropped: drift surfaces at runtime instead
-// of silently creating a counter on first use.
+// Interceptor returns the gRPC UnaryServerInterceptor that increments
+// per-method counters and records the request-duration histogram. Any
+// counter or histogram it touches must already exist in m.counters /
+// m.requestDurationHist, populated by Metrics(); inc() logs an error on
+// missing entries.
 func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -117,8 +108,8 @@ func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 }
 
 // inc increments the grpc.server.<id> and <legacyMetricsPrefix><id>
-// counters. Both must already exist in m.counters, populated by Metrics()
-// at construction; a missing entry is a drift bug and is logged.
+// counters. A missing entry means Metrics() didn't eagerly create it and
+// is logged as an error.
 func (m *metricsInterceptor) inc(legacyMetricsPrefix string, id request.ResultID) {
 	server, sok := m.counters[counterKey{prefix: grpcServerPrefix, id: id}]
 	legacy, lok := m.counters[counterKey{prefix: legacyMetricsPrefix, id: id}]

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -36,6 +36,16 @@ const (
 	requestDurationHistogram = "request.duration"
 )
 
+// otlpGRPCLegacyMetricsPrefixes maps each OTLP gRPC service method to its
+// legacy "apm-server.otlp.grpc.<signal>." metric prefix. Single source of
+// truth for both the per-call dispatch in Interceptor() and the eager
+// registration loop in Metrics(); adding a new signal means one entry.
+var otlpGRPCLegacyMetricsPrefixes = map[string]string{
+	"/opentelemetry.proto.collector.metrics.v1.MetricsService/Export": "apm-server.otlp.grpc.metrics.",
+	"/opentelemetry.proto.collector.trace.v1.TraceService/Export":     "apm-server.otlp.grpc.traces.",
+	"/opentelemetry.proto.collector.logs.v1.LogsService/Export":       "apm-server.otlp.grpc.logs.",
+}
+
 type metricsInterceptor struct {
 	logger *logp.Logger
 	meter  metric.Meter
@@ -51,16 +61,8 @@ func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		var legacyMetricsPrefix string
-
-		switch info.FullMethod {
-		case "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export":
-			legacyMetricsPrefix = "apm-server.otlp.grpc.metrics."
-		case "/opentelemetry.proto.collector.trace.v1.TraceService/Export":
-			legacyMetricsPrefix = "apm-server.otlp.grpc.traces."
-		case "/opentelemetry.proto.collector.logs.v1.LogsService/Export":
-			legacyMetricsPrefix = "apm-server.otlp.grpc.logs."
-		default:
+		legacyMetricsPrefix, ok := otlpGRPCLegacyMetricsPrefixes[info.FullMethod]
+		if !ok {
 			m.logger.With(
 				"grpc.request.method", info.FullMethod,
 			).Warn("metrics registry missing")
@@ -119,15 +121,6 @@ func (m *metricsInterceptor) getHistogram(n string, opts ...metric.Int64Histogra
 	return met.(metric.Int64Histogram)
 }
 
-// otlpLegacyMetricsPrefixes lists every legacy metric prefix the metrics
-// interceptor records under. Used to eagerly register counters at startup
-// so /stats enumerates each metric from process start.
-var otlpLegacyMetricsPrefixes = []string{
-	"apm-server.otlp.grpc.metrics.",
-	"apm-server.otlp.grpc.traces.",
-	"apm-server.otlp.grpc.logs.",
-}
-
 // Metrics returns a grpc.UnaryServerInterceptor that increments metrics
 // for gRPC method calls.
 //
@@ -149,7 +142,7 @@ func Metrics(logger *logp.Logger, mp metric.MeterProvider) grpc.UnaryServerInter
 
 	for _, id := range request.AllResultIDs {
 		i.getCounter("grpc.server.", string(id))
-		for _, prefix := range otlpLegacyMetricsPrefixes {
+		for _, prefix := range otlpGRPCLegacyMetricsPrefixes {
 			i.getCounter(prefix, string(id))
 		}
 	}

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -63,8 +63,8 @@ type metricsInterceptor struct {
 // Interceptor returns the gRPC UnaryServerInterceptor that increments
 // per-method counters and records the request-duration histogram. Any
 // counter or histogram it touches must already exist in m.counters /
-// m.requestDurationHist, populated by Metrics(); inc() logs an error on
-// missing entries.
+// m.requestDurationHist, populated by Metrics(); a missing entry is an
+// apm-server bug logged by inc().
 func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -108,8 +108,8 @@ func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 }
 
 // inc increments the grpc.server.<id> and <legacyMetricsPrefix><id>
-// counters. A missing entry means Metrics() didn't eagerly create it and
-// is logged as an error.
+// counters. A missing entry is an apm-server bug: Metrics() must eagerly
+// create every counter inc() can use.
 func (m *metricsInterceptor) inc(legacyMetricsPrefix string, id request.ResultID) {
 	server, sok := m.counters[counterKey{prefix: grpcServerPrefix, id: id}]
 	legacy, lok := m.counters[counterKey{prefix: legacyMetricsPrefix, id: id}]
@@ -117,7 +117,7 @@ func (m *metricsInterceptor) inc(legacyMetricsPrefix string, id request.ResultID
 		m.logger.With(
 			"prefix", legacyMetricsPrefix,
 			"id", string(id),
-		).Error("monitoring counter not eagerly registered")
+		).Error("BUG: monitoring counter missing from eager registration")
 		return
 	}
 	ctx := context.Background()

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -26,9 +26,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/elastic/elastic-agent-libs/logp"
+
 	"github.com/elastic/apm-server/internal/beater/request"
 	"github.com/elastic/apm-server/internal/otelmetric"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 const (

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -112,18 +112,20 @@ func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 // counters. A missing entry is an apm-server bug: Metrics() must eagerly
 // create every counter inc() can use.
 func (m *metricsInterceptor) inc(legacyMetricsPrefix string, id request.ResultID) {
-	server, sok := m.counters[counterKey{prefix: grpcServerPrefix, id: id}]
-	legacy, lok := m.counters[counterKey{prefix: legacyMetricsPrefix, id: id}]
-	if !sok || !lok {
-		m.logger.With(
-			"prefix", legacyMetricsPrefix,
-			"id", string(id),
-		).Error("BUG: monitoring counter missing from eager registration")
+	m.incOne(grpcServerPrefix, id)
+	m.incOne(legacyMetricsPrefix, id)
+}
+
+// incOne adds 1 to the counter for (prefix, id). A missing entry logs
+// the BUG and is otherwise a no-op.
+func (m *metricsInterceptor) incOne(prefix string, id request.ResultID) {
+	c, ok := m.counters[counterKey{prefix: prefix, id: id}]
+	if !ok {
+		m.logger.With("name", prefix+string(id)).
+			Error("BUG: monitoring counter missing from eager registration")
 		return
 	}
-	ctx := context.Background()
-	server.Add(ctx, 1)
-	legacy.Add(ctx, 1)
+	c.Add(context.Background(), 1)
 }
 
 // Metrics returns a grpc.UnaryServerInterceptor that increments metrics

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -19,7 +19,6 @@ package interceptors
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
@@ -34,6 +33,7 @@ import (
 
 const (
 	requestDurationHistogram = "request.duration"
+	grpcServerPrefix         = "grpc.server."
 )
 
 // otlpGRPCLegacyMetricsPrefixes maps each OTLP gRPC service method to its
@@ -46,14 +46,34 @@ var otlpGRPCLegacyMetricsPrefixes = map[string]string{
 	"/opentelemetry.proto.collector.logs.v1.LogsService/Export":       "apm-server.otlp.grpc.logs.",
 }
 
-type metricsInterceptor struct {
-	logger *logp.Logger
-	meter  metric.Meter
-
-	counters   sync.Map
-	histograms sync.Map
+// counterKey identifies a counter by its (prefix, ResultID) tuple. Used as
+// the map key in metricsInterceptor.counters; struct keys avoid the
+// per-call allocation of "prefix + id" string concatenation.
+type counterKey struct {
+	prefix string
+	id     request.ResultID
 }
 
+type metricsInterceptor struct {
+	logger *logp.Logger
+
+	// counters holds every counter the interceptor will ever record
+	// against. Populated once in Metrics() before the interceptor is
+	// returned; read-only thereafter, which makes plain map access safe
+	// for concurrent reads. Lookup misses are reported via logger and
+	// otherwise treated as no-ops; see the drift contract.
+	counters            map[counterKey]metric.Int64Counter
+	requestDurationHist metric.Int64Histogram
+}
+
+// Drift contract: every prefix the inner closure passes to m.inc() comes
+// from otlpGRPCLegacyMetricsPrefixes (via the lookup below); every
+// request.ResultID it passes must appear in request.AllResultIDs. The
+// eager-registration loop in Metrics() iterates the cross-product of
+// those two sets and pre-populates m.counters. Any (prefix, id) pair the
+// inner closure tries to use that wasn't pre-populated is reported via
+// logger.Error and otherwise dropped: drift surfaces at runtime instead
+// of silently creating a counter on first use.
 func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -75,7 +95,7 @@ func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 		start := time.Now()
 		resp, err := handler(ctx, req)
 		duration := time.Since(start)
-		m.getHistogram(requestDurationHistogram, metric.WithUnit("ms")).Record(context.Background(), duration.Milliseconds())
+		m.requestDurationHist.Record(context.Background(), duration.Milliseconds())
 
 		responseID := request.IDResponseValidCount
 		if err != nil {
@@ -96,29 +116,22 @@ func (m *metricsInterceptor) Interceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
+// inc increments the grpc.server.<id> and <legacyMetricsPrefix><id>
+// counters. Both must already exist in m.counters, populated by Metrics()
+// at construction; a missing entry is a drift bug and is logged.
 func (m *metricsInterceptor) inc(legacyMetricsPrefix string, id request.ResultID) {
-	m.getCounter("grpc.server.", string(id)).Add(context.Background(), 1)
-	m.getCounter(legacyMetricsPrefix, string(id)).Add(context.Background(), 1)
-}
-
-func (m *metricsInterceptor) getCounter(prefix, n string) metric.Int64Counter {
-	name := prefix + n
-	if met, ok := m.counters.Load(name); ok {
-		return met.(metric.Int64Counter)
+	server, sok := m.counters[counterKey{prefix: grpcServerPrefix, id: id}]
+	legacy, lok := m.counters[counterKey{prefix: legacyMetricsPrefix, id: id}]
+	if !sok || !lok {
+		m.logger.With(
+			"prefix", legacyMetricsPrefix,
+			"id", string(id),
+		).Error("monitoring counter not eagerly registered")
+		return
 	}
-	nm := otelmetric.NewInt64Counter(m.meter, name)
-	met, _ := m.counters.LoadOrStore(name, nm)
-	return met.(metric.Int64Counter)
-}
-
-func (m *metricsInterceptor) getHistogram(n string, opts ...metric.Int64HistogramOption) metric.Int64Histogram {
-	name := "grpc.server." + n
-	if met, ok := m.histograms.Load(name); ok {
-		return met.(metric.Int64Histogram)
-	}
-	nm, _ := m.meter.Int64Histogram(name, opts...)
-	met, _ := m.histograms.LoadOrStore(name, nm)
-	return met.(metric.Int64Histogram)
+	ctx := context.Background()
+	server.Add(ctx, 1)
+	legacy.Add(ctx, 1)
 }
 
 // Metrics returns a grpc.UnaryServerInterceptor that increments metrics
@@ -132,20 +145,27 @@ func (m *metricsInterceptor) getHistogram(n string, opts ...metric.Int64Histogra
 // if neither of these are available, a warning will be logged and no metrics
 // will be gathered.
 func Metrics(logger *logp.Logger, mp metric.MeterProvider) grpc.UnaryServerInterceptor {
-	i := &metricsInterceptor{
-		logger: logger,
-		meter:  mp.Meter("github.com/elastic/apm-server/internal/beater/interceptors"),
+	meter := mp.Meter("github.com/elastic/apm-server/internal/beater/interceptors")
+	requestDurationHist, _ := meter.Int64Histogram(
+		grpcServerPrefix+requestDurationHistogram,
+		metric.WithUnit("ms"),
+	)
 
-		counters:   sync.Map{},
-		histograms: sync.Map{},
-	}
-
+	// Eager registration: pre-populate every (prefix, id) pair the
+	// interceptor can ever record against. Done once before the
+	// interceptor is returned, so subsequent map reads are concurrent-safe.
+	counters := make(map[counterKey]metric.Int64Counter, len(request.AllResultIDs)*(len(otlpGRPCLegacyMetricsPrefixes)+1))
 	for _, id := range request.AllResultIDs {
-		i.getCounter("grpc.server.", string(id))
+		counters[counterKey{prefix: grpcServerPrefix, id: id}] = otelmetric.NewInt64Counter(meter, grpcServerPrefix+string(id))
 		for _, prefix := range otlpGRPCLegacyMetricsPrefixes {
-			i.getCounter(prefix, string(id))
+			counters[counterKey{prefix: prefix, id: id}] = otelmetric.NewInt64Counter(meter, prefix+string(id))
 		}
 	}
 
+	i := &metricsInterceptor{
+		logger:              logger,
+		counters:            counters,
+		requestDurationHist: requestDurationHist,
+	}
 	return i.Interceptor()
 }

--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -160,7 +160,21 @@ func TestMetrics(t *testing.T) {
 
 				interceptor(ctx, nil, info, tc.f)
 
+				// Metrics() eagerly zero-initializes the cross product of
+				// these prefixes and request.AllResultIDs. Build the full
+				// expected map starting from those zeros, then override
+				// with the non-zero values the test fires.
 				expectedMetrics := make(map[string]any)
+				for _, prefix := range []string{
+					"grpc.server.",
+					"apm-server.otlp.grpc.metrics.",
+					"apm-server.otlp.grpc.traces.",
+					"apm-server.otlp.grpc.logs.",
+				} {
+					for _, id := range request.AllResultIDs {
+						expectedMetrics[prefix+string(id)] = int64(0)
+					}
+				}
 				for k, v := range tc.expectedOtel {
 					expectedMetrics["grpc.server."+k] = v
 					if k != "request.duration" {
@@ -168,16 +182,7 @@ func TestMetrics(t *testing.T) {
 					}
 				}
 
-				// Metrics() eagerly zero-initializes counters under these
-				// prefixes; unlisted counters under them must be 0.
-				monitoringtest.ExpectOtelMetrics(t, reader, expectedMetrics,
-					monitoringtest.WithEagerPrefixes(
-						"grpc.server.",
-						"apm-server.otlp.grpc.metrics.",
-						"apm-server.otlp.grpc.traces.",
-						"apm-server.otlp.grpc.logs.",
-					),
-				)
+				monitoringtest.ExpectOtelMetrics(t, reader, expectedMetrics)
 			})
 		}
 	}

--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -160,18 +160,7 @@ func TestMetrics(t *testing.T) {
 
 				interceptor(ctx, nil, info, tc.f)
 
-				// Metrics() eagerly zero-initializes the cross product of
-				// these prefixes and request.AllResultIDs; only the non-
-				// zero values from tc.expectedOtel are set explicitly.
-				expectedMetrics := monitoringtest.EagerCountersZeros(
-					[]string{
-						"grpc.server.",
-						"apm-server.otlp.grpc.metrics.",
-						"apm-server.otlp.grpc.traces.",
-						"apm-server.otlp.grpc.logs.",
-					},
-					request.AllResultIDs,
-				)
+				expectedMetrics := make(map[string]any)
 				for k, v := range tc.expectedOtel {
 					expectedMetrics["grpc.server."+k] = v
 					if k != "request.duration" {
@@ -179,7 +168,16 @@ func TestMetrics(t *testing.T) {
 					}
 				}
 
-				monitoringtest.ExpectOtelMetrics(t, reader, expectedMetrics)
+				// Metrics() eagerly zero-initializes counters under these
+				// prefixes; unlisted counters under them must be 0.
+				monitoringtest.ExpectOtelMetrics(t, reader, expectedMetrics,
+					monitoringtest.WithEagerPrefixes(
+						"grpc.server.",
+						"apm-server.otlp.grpc.metrics.",
+						"apm-server.otlp.grpc.traces.",
+						"apm-server.otlp.grpc.logs.",
+					),
+				)
 			})
 		}
 	}

--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -225,3 +225,23 @@ func TestMetrics_ConcurrentSafe(t *testing.T) {
 		"grpc.server.request.count": numG,
 	})
 }
+
+func BenchmarkInterceptor(b *testing.B) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	logger := logptest.NewTestingLogger(b, "interceptor.metrics.bench")
+	interceptor := Metrics(logger, mp)
+
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return req, nil
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = interceptor(ctx, "hello", info, handler)
+	}
+}

--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -160,14 +160,21 @@ func TestMetrics(t *testing.T) {
 
 				interceptor(ctx, nil, info, tc.f)
 
-				expectedMetrics := make(map[string]any, 2*len(tc.expectedOtel))
-
+				// Metrics() eagerly zero-initializes the cross product of
+				// these prefixes and request.AllResultIDs; only the non-
+				// zero values from tc.expectedOtel are set explicitly.
+				expectedMetrics := monitoringtest.EagerCountersZeros(
+					[]string{
+						"grpc.server.",
+						"apm-server.otlp.grpc.metrics.",
+						"apm-server.otlp.grpc.traces.",
+						"apm-server.otlp.grpc.logs.",
+					},
+					request.AllResultIDs,
+				)
 				for k, v := range tc.expectedOtel {
-					// add otel metrics
 					expectedMetrics["grpc.server."+k] = v
-
 					if k != "request.duration" {
-						// add legacy metrics
 						expectedMetrics[metrics.prefix+k] = v
 					}
 				}

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -74,18 +74,21 @@ func (m *monitoringMiddleware) Middleware() Middleware {
 // counters. A missing entry is an apm-server bug: MonitoringMiddleware()
 // must eagerly create every counter inc() can use.
 func (m *monitoringMiddleware) inc(id request.ResultID) {
-	server, sok := m.serverCounters[id]
-	legacy, lok := m.legacyCounters[id]
-	if !sok || !lok {
-		m.logger.With(
-			"prefix", m.legacyMetricsPrefix,
-			"id", string(id),
-		).Error("BUG: monitoring counter missing from eager registration")
+	m.incOne(m.serverCounters, httpServerPrefix, id)
+	m.incOne(m.legacyCounters, m.legacyMetricsPrefix, id)
+}
+
+// incOne adds 1 to counters[id]. A missing entry logs the BUG (with
+// prefix only used to build the full metric name) and is otherwise a
+// no-op.
+func (m *monitoringMiddleware) incOne(counters map[request.ResultID]metric.Int64Counter, prefix string, id request.ResultID) {
+	c, ok := counters[id]
+	if !ok {
+		m.logger.With("name", prefix+string(id)).
+			Error("BUG: monitoring counter missing from eager registration")
 		return
 	}
-	ctx := context.Background()
-	server.Add(ctx, 1)
-	legacy.Add(ctx, 1)
+	c.Add(context.Background(), 1)
 }
 
 // MonitoringMiddleware returns a middleware that increments monitoring

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/elastic/apm-server/internal/beater/request"
+	"github.com/elastic/apm-server/internal/otelmetric"
 )
 
 const (
@@ -72,7 +73,7 @@ func (m *monitoringMiddleware) getCounter(prefix, name string) metric.Int64Count
 	if met, ok := m.counters.Load(name); ok {
 		return met.(metric.Int64Counter)
 	}
-	nm, _ := m.meter.Int64Counter(name)
+	nm := otelmetric.NewInt64Counter(m.meter, name)
 	met, _ := m.counters.LoadOrStore(name, nm)
 	return met.(metric.Int64Counter)
 }
@@ -82,7 +83,6 @@ func (m *monitoringMiddleware) getHistogram(n string, opts ...metric.Int64Histog
 	if met, ok := m.histograms.Load(name); ok {
 		return met.(metric.Int64Histogram)
 	}
-
 	nm, _ := m.meter.Int64Histogram(name, opts...)
 	met, _ := m.histograms.LoadOrStore(name, nm)
 	return met.(metric.Int64Histogram)
@@ -90,12 +90,22 @@ func (m *monitoringMiddleware) getHistogram(n string, opts ...metric.Int64Histog
 
 // MonitoringMiddleware returns a middleware that increases monitoring counters for collecting metrics
 // about request processing. As input parameter it takes a map capable of mapping a request.ResultID to a counter.
+//
+// All counters for the canonical request.AllResultIDs set are created
+// eagerly at construction so /stats enumerates every metric name from
+// process start. The zero-init happens inside getCounter; this loop just
+// triggers creation. See request.AllResultIDs for the rationale.
 func MonitoringMiddleware(legacyMetricsPrefix string, mp metric.MeterProvider) Middleware {
 	mid := &monitoringMiddleware{
 		meter:               mp.Meter("github.com/elastic/apm-server/internal/beater/middleware"),
 		legacyMetricsPrefix: legacyMetricsPrefix,
 		counters:            sync.Map{},
 		histograms:          sync.Map{},
+	}
+
+	for _, id := range request.AllResultIDs {
+		mid.getCounter("http.server.", string(id))
+		mid.getCounter(legacyMetricsPrefix, string(id))
 	}
 
 	return mid.Middleware()

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -42,6 +42,11 @@ type monitoringMiddleware struct {
 }
 
 func (m *monitoringMiddleware) Middleware() Middleware {
+	// Every ResultID passed to m.inc() below must also appear in
+	// request.AllResultIDs so the corresponding counter is eagerly
+	// registered in MonitoringMiddleware(). c.Result.ID is set by request
+	// handlers from keys of MapResultIDToStatus; the four unconditional
+	// IDs are part of AllResultIDs's hand-maintained list.
 	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 			m.inc(request.IDRequestCount)
@@ -91,10 +96,15 @@ func (m *monitoringMiddleware) getHistogram(n string, opts ...metric.Int64Histog
 // MonitoringMiddleware returns a middleware that increases monitoring counters for collecting metrics
 // about request processing. As input parameter it takes a map capable of mapping a request.ResultID to a counter.
 //
-// All counters for the canonical request.AllResultIDs set are created
-// eagerly at construction so /stats enumerates every metric name from
-// process start. The zero-init happens inside getCounter; this loop just
-// triggers creation. See request.AllResultIDs for the rationale.
+// Counters for the canonical request.AllResultIDs set are created eagerly
+// at construction so /stats enumerates every metric name from process
+// start. The zero-init happens inside getCounter; this loop just triggers
+// creation. See request.AllResultIDs for the rationale.
+//
+// Drift contract: Middleware()'s m.inc() calls above must only pass IDs
+// from request.AllResultIDs. New ResultIDs introduced into the inc()
+// paths must be added to AllResultIDs (or MapResultIDToStatus, which
+// feeds it).
 func MonitoringMiddleware(legacyMetricsPrefix string, mp metric.MeterProvider) Middleware {
 	mid := &monitoringMiddleware{
 		meter:               mp.Meter("github.com/elastic/apm-server/internal/beater/middleware"),

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -24,9 +24,10 @@ import (
 
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/elastic/elastic-agent-libs/logp"
+
 	"github.com/elastic/apm-server/internal/beater/request"
 	"github.com/elastic/apm-server/internal/otelmetric"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 const (

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -45,7 +45,8 @@ type monitoringMiddleware struct {
 // Middleware returns the request.Middleware that increments per-request
 // counters and records the request-duration histogram. Any counter or
 // histogram it touches must already exist in the maps populated by
-// MonitoringMiddleware(); inc() logs an error on missing entries.
+// MonitoringMiddleware(); a missing entry is an apm-server bug logged
+// by inc().
 func (m *monitoringMiddleware) Middleware() Middleware {
 	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
@@ -69,8 +70,8 @@ func (m *monitoringMiddleware) Middleware() Middleware {
 }
 
 // inc increments the http.server.<id> and <legacyMetricsPrefix><id>
-// counters. A missing entry means MonitoringMiddleware() didn't eagerly
-// create it and is logged as an error.
+// counters. A missing entry is an apm-server bug: MonitoringMiddleware()
+// must eagerly create every counter inc() can use.
 func (m *monitoringMiddleware) inc(id request.ResultID) {
 	server, sok := m.serverCounters[id]
 	legacy, lok := m.legacyCounters[id]
@@ -78,7 +79,7 @@ func (m *monitoringMiddleware) inc(id request.ResultID) {
 		m.logger.With(
 			"prefix", m.legacyMetricsPrefix,
 			"id", string(id),
-		).Error("monitoring counter not eagerly registered")
+		).Error("BUG: monitoring counter missing from eager registration")
 		return
 	}
 	ctx := context.Background()

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -20,33 +20,33 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/elastic/apm-server/internal/beater/request"
 	"github.com/elastic/apm-server/internal/otelmetric"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 const (
 	requestDurationHistogram = "request.duration"
+	httpServerPrefix         = "http.server."
 )
 
 type monitoringMiddleware struct {
-	meter               metric.Meter
+	logger              *logp.Logger
 	legacyMetricsPrefix string
-
-	counters   sync.Map
-	histograms sync.Map
+	serverCounters      map[request.ResultID]metric.Int64Counter
+	legacyCounters      map[request.ResultID]metric.Int64Counter
+	requestDurationHist metric.Int64Histogram
 }
 
+// Middleware returns the request.Middleware that increments per-request
+// counters and records the request-duration histogram. Any counter or
+// histogram it touches must already exist in the maps populated by
+// MonitoringMiddleware(); inc() logs an error on missing entries.
 func (m *monitoringMiddleware) Middleware() Middleware {
-	// Every ResultID passed to m.inc() below must also appear in
-	// request.AllResultIDs so the corresponding counter is eagerly
-	// registered in MonitoringMiddleware(). c.Result.ID is set by request
-	// handlers from keys of MapResultIDToStatus; the four unconditional
-	// IDs are part of AllResultIDs's hand-maintained list.
 	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 			m.inc(request.IDRequestCount)
@@ -54,7 +54,7 @@ func (m *monitoringMiddleware) Middleware() Middleware {
 			start := time.Now()
 			h(c)
 			duration := time.Since(start)
-			m.getHistogram(requestDurationHistogram, metric.WithUnit("ms")).Record(context.Background(), duration.Milliseconds())
+			m.requestDurationHist.Record(context.Background(), duration.Milliseconds())
 
 			m.inc(request.IDResponseCount)
 			if c.Result.StatusCode >= http.StatusBadRequest {
@@ -68,55 +68,52 @@ func (m *monitoringMiddleware) Middleware() Middleware {
 	}
 }
 
+// inc increments the http.server.<id> and <legacyMetricsPrefix><id>
+// counters. A missing entry means MonitoringMiddleware() didn't eagerly
+// create it and is logged as an error.
 func (m *monitoringMiddleware) inc(id request.ResultID) {
-	m.getCounter("http.server.", string(id)).Add(context.Background(), 1)
-	m.getCounter(m.legacyMetricsPrefix, string(id)).Add(context.Background(), 1)
-}
-
-func (m *monitoringMiddleware) getCounter(prefix, name string) metric.Int64Counter {
-	name = prefix + name
-	if met, ok := m.counters.Load(name); ok {
-		return met.(metric.Int64Counter)
+	server, sok := m.serverCounters[id]
+	legacy, lok := m.legacyCounters[id]
+	if !sok || !lok {
+		m.logger.With(
+			"prefix", m.legacyMetricsPrefix,
+			"id", string(id),
+		).Error("monitoring counter not eagerly registered")
+		return
 	}
-	nm := otelmetric.NewInt64Counter(m.meter, name)
-	met, _ := m.counters.LoadOrStore(name, nm)
-	return met.(metric.Int64Counter)
+	ctx := context.Background()
+	server.Add(ctx, 1)
+	legacy.Add(ctx, 1)
 }
 
-func (m *monitoringMiddleware) getHistogram(n string, opts ...metric.Int64HistogramOption) metric.Int64Histogram {
-	name := "http.server." + n
-	if met, ok := m.histograms.Load(name); ok {
-		return met.(metric.Int64Histogram)
-	}
-	nm, _ := m.meter.Int64Histogram(name, opts...)
-	met, _ := m.histograms.LoadOrStore(name, nm)
-	return met.(metric.Int64Histogram)
-}
-
-// MonitoringMiddleware returns a middleware that increases monitoring counters for collecting metrics
-// about request processing. As input parameter it takes a map capable of mapping a request.ResultID to a counter.
+// MonitoringMiddleware returns a middleware that increments monitoring
+// counters for collecting metrics about request processing.
 //
-// Counters for the canonical request.AllResultIDs set are created eagerly
-// at construction so /stats enumerates every metric name from process
-// start. The zero-init happens inside getCounter; this loop just triggers
-// creation. See request.AllResultIDs for the rationale.
-//
-// Drift contract: Middleware()'s m.inc() calls above must only pass IDs
-// from request.AllResultIDs. New ResultIDs introduced into the inc()
-// paths must be added to AllResultIDs (or MapResultIDToStatus, which
-// feeds it).
-func MonitoringMiddleware(legacyMetricsPrefix string, mp metric.MeterProvider) Middleware {
-	mid := &monitoringMiddleware{
-		meter:               mp.Meter("github.com/elastic/apm-server/internal/beater/middleware"),
-		legacyMetricsPrefix: legacyMetricsPrefix,
-		counters:            sync.Map{},
-		histograms:          sync.Map{},
-	}
+// All counters for the canonical request.AllResultIDs set are created
+// eagerly; the maps are read-only after construction so plain map access
+// is safe across concurrent requests. Any new ResultID introduced into
+// Middleware()'s inc() paths must be added to AllResultIDs (or
+// MapResultIDToStatus, which feeds it).
+func MonitoringMiddleware(legacyMetricsPrefix string, mp metric.MeterProvider, logger *logp.Logger) Middleware {
+	meter := mp.Meter("github.com/elastic/apm-server/internal/beater/middleware")
+	requestDurationHist, _ := meter.Int64Histogram(
+		httpServerPrefix+requestDurationHistogram,
+		metric.WithUnit("ms"),
+	)
 
+	serverCounters := make(map[request.ResultID]metric.Int64Counter, len(request.AllResultIDs))
+	legacyCounters := make(map[request.ResultID]metric.Int64Counter, len(request.AllResultIDs))
 	for _, id := range request.AllResultIDs {
-		mid.getCounter("http.server.", string(id))
-		mid.getCounter(legacyMetricsPrefix, string(id))
+		serverCounters[id] = otelmetric.NewInt64Counter(meter, httpServerPrefix+string(id))
+		legacyCounters[id] = otelmetric.NewInt64Counter(meter, legacyMetricsPrefix+string(id))
 	}
 
+	mid := &monitoringMiddleware{
+		logger:              logger,
+		legacyMetricsPrefix: legacyMetricsPrefix,
+		serverCounters:      serverCounters,
+		legacyCounters:      legacyCounters,
+		requestDurationHist: requestDurationHist,
+	}
 	return mid.Middleware()
 }

--- a/internal/beater/middleware/monitoring_middleware_test.go
+++ b/internal/beater/middleware/monitoring_middleware_test.go
@@ -169,3 +169,15 @@ func TestMonitoringHandler(t *testing.T) {
 		})
 	})
 }
+
+func BenchmarkMonitoringMiddleware(b *testing.B) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	handler := Apply(MonitoringMiddleware("apm-server.foo.", mp), HandlerIdle)
+
+	c, _ := DefaultContextWithResponseRecorder()
+	b.ReportAllocs()
+	for b.Loop() {
+		handler(c)
+	}
+}

--- a/internal/beater/middleware/monitoring_middleware_test.go
+++ b/internal/beater/middleware/monitoring_middleware_test.go
@@ -18,7 +18,6 @@
 package middleware
 
 import (
-	"maps"
 	"sync"
 	"testing"
 
@@ -31,10 +30,9 @@ import (
 )
 
 func TestMonitoringHandler(t *testing.T) {
-	// MonitoringMiddleware eagerly zero-initializes the cross product of
-	// these prefixes and request.AllResultIDs; tests only specify
-	// overrides for the counters they expect to be non-zero.
-	eagerPrefixes := []string{"http.server.", ""}
+	// MonitoringMiddleware eagerly zero-initializes counters under these
+	// prefixes; tests only specify overrides for the non-zero counters.
+	eagerInit := monitoringtest.WithEagerPrefixes("http.server.", "")
 
 	checkMonitoring := func(t *testing.T,
 		h func(*request.Context),
@@ -51,9 +49,7 @@ func TestMonitoringHandler(t *testing.T) {
 		logger := logptest.NewTestingLogger(t, "monitoring-middleware.test")
 		Apply(MonitoringMiddleware("", mp, logger), h)(c)
 
-		expected := monitoringtest.EagerCountersZeros(eagerPrefixes, request.AllResultIDs)
-		maps.Copy(expected, overrides)
-		monitoringtest.ExpectOtelMetrics(t, reader, expected)
+		monitoringtest.ExpectOtelMetrics(t, reader, overrides, eagerInit)
 	}
 
 	t.Run("Error", func(t *testing.T) {
@@ -166,8 +162,7 @@ func TestMonitoringHandler(t *testing.T) {
 			}()
 		}
 		wg.Wait()
-		expected := monitoringtest.EagerCountersZeros(eagerPrefixes, request.AllResultIDs)
-		maps.Copy(expected, map[string]any{
+		monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
 			"http.server." + string(request.IDRequestCount):       i,
 			"http.server." + string(request.IDResponseCount):      i,
 			"http.server." + string(request.IDResponseValidCount): i,
@@ -178,8 +173,7 @@ func TestMonitoringHandler(t *testing.T) {
 			string(request.IDUnset):                               i,
 
 			"http.server.request.duration": i,
-		})
-		monitoringtest.ExpectOtelMetrics(t, reader, expected)
+		}, eagerInit)
 	})
 }
 

--- a/internal/beater/middleware/monitoring_middleware_test.go
+++ b/internal/beater/middleware/monitoring_middleware_test.go
@@ -30,9 +30,20 @@ import (
 )
 
 func TestMonitoringHandler(t *testing.T) {
-	// MonitoringMiddleware eagerly zero-initializes counters under these
-	// prefixes; tests only specify overrides for the non-zero counters.
-	eagerInit := monitoringtest.WithEagerPrefixes("http.server.", "")
+	// eagerZeros returns the cross product of MonitoringMiddleware's
+	// eagerly initialized prefixes (http.server. and the empty legacy
+	// prefix) with request.AllResultIDs, all set to 0. Tests merge
+	// overrides into this map so the assertion is a strict full match
+	// against the gathered set.
+	eagerZeros := func() map[string]any {
+		m := map[string]any{}
+		for _, prefix := range []string{"http.server.", ""} {
+			for _, id := range request.AllResultIDs {
+				m[prefix+string(id)] = int64(0)
+			}
+		}
+		return m
+	}
 
 	checkMonitoring := func(t *testing.T,
 		h func(*request.Context),
@@ -49,7 +60,11 @@ func TestMonitoringHandler(t *testing.T) {
 		logger := logptest.NewTestingLogger(t, "monitoring-middleware.test")
 		Apply(MonitoringMiddleware("", mp, logger), h)(c)
 
-		monitoringtest.ExpectOtelMetrics(t, reader, overrides, eagerInit)
+		expected := eagerZeros()
+		for k, v := range overrides {
+			expected[k] = v
+		}
+		monitoringtest.ExpectOtelMetrics(t, reader, expected)
 	}
 
 	t.Run("Error", func(t *testing.T) {
@@ -162,7 +177,8 @@ func TestMonitoringHandler(t *testing.T) {
 			}()
 		}
 		wg.Wait()
-		monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+		expected := eagerZeros()
+		for k, v := range map[string]any{
 			"http.server." + string(request.IDRequestCount):       i,
 			"http.server." + string(request.IDResponseCount):      i,
 			"http.server." + string(request.IDResponseValidCount): i,
@@ -173,7 +189,10 @@ func TestMonitoringHandler(t *testing.T) {
 			string(request.IDUnset):                               i,
 
 			"http.server.request.duration": i,
-		}, eagerInit)
+		} {
+			expected[k] = v
+		}
+		monitoringtest.ExpectOtelMetrics(t, reader, expected)
 	})
 }
 

--- a/internal/beater/middleware/monitoring_middleware_test.go
+++ b/internal/beater/middleware/monitoring_middleware_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/apm-server/internal/beater/monitoringtest"
 	"github.com/elastic/apm-server/internal/beater/request"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestMonitoringHandler(t *testing.T) {
@@ -41,7 +42,8 @@ func TestMonitoringHandler(t *testing.T) {
 		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 
 		c, _ := DefaultContextWithResponseRecorder()
-		Apply(MonitoringMiddleware("", mp), h)(c)
+		logger := logptest.NewTestingLogger(t, "monitoring-middleware.test")
+		Apply(MonitoringMiddleware("", mp, logger), h)(c)
 
 		monitoringtest.ExpectOtelMetrics(t, reader, expectedOtel)
 	}
@@ -144,7 +146,8 @@ func TestMonitoringHandler(t *testing.T) {
 			},
 		))
 		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-		m := MonitoringMiddleware("", mp)
+		logger := logptest.NewTestingLogger(t, "monitoring-middleware.test")
+		m := MonitoringMiddleware("", mp, logger)
 		c, _ := DefaultContextWithResponseRecorder()
 		var wg sync.WaitGroup
 		for range i {
@@ -173,7 +176,8 @@ func TestMonitoringHandler(t *testing.T) {
 func BenchmarkMonitoringMiddleware(b *testing.B) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	handler := Apply(MonitoringMiddleware("apm-server.foo.", mp), HandlerIdle)
+	logger := logptest.NewTestingLogger(b, "monitoring-middleware.bench")
+	handler := Apply(MonitoringMiddleware("apm-server.foo.", mp, logger), HandlerIdle)
 
 	c, _ := DefaultContextWithResponseRecorder()
 	b.ReportAllocs()

--- a/internal/beater/middleware/monitoring_middleware_test.go
+++ b/internal/beater/middleware/monitoring_middleware_test.go
@@ -18,6 +18,7 @@
 package middleware
 
 import (
+	"maps"
 	"sync"
 	"testing"
 
@@ -30,9 +31,14 @@ import (
 )
 
 func TestMonitoringHandler(t *testing.T) {
+	// MonitoringMiddleware eagerly zero-initializes the cross product of
+	// these prefixes and request.AllResultIDs; tests only specify
+	// overrides for the counters they expect to be non-zero.
+	eagerPrefixes := []string{"http.server.", ""}
+
 	checkMonitoring := func(t *testing.T,
 		h func(*request.Context),
-		expectedOtel map[string]interface{},
+		overrides map[string]any,
 	) {
 		reader := sdkmetric.NewManualReader(sdkmetric.WithTemporalitySelector(
 			func(ik sdkmetric.InstrumentKind) metricdata.Temporality {
@@ -45,7 +51,9 @@ func TestMonitoringHandler(t *testing.T) {
 		logger := logptest.NewTestingLogger(t, "monitoring-middleware.test")
 		Apply(MonitoringMiddleware("", mp, logger), h)(c)
 
-		monitoringtest.ExpectOtelMetrics(t, reader, expectedOtel)
+		expected := monitoringtest.EagerCountersZeros(eagerPrefixes, request.AllResultIDs)
+		maps.Copy(expected, overrides)
+		monitoringtest.ExpectOtelMetrics(t, reader, expected)
 	}
 
 	t.Run("Error", func(t *testing.T) {
@@ -158,7 +166,8 @@ func TestMonitoringHandler(t *testing.T) {
 			}()
 		}
 		wg.Wait()
-		monitoringtest.ExpectOtelMetrics(t, reader, map[string]interface{}{
+		expected := monitoringtest.EagerCountersZeros(eagerPrefixes, request.AllResultIDs)
+		maps.Copy(expected, map[string]any{
 			"http.server." + string(request.IDRequestCount):       i,
 			"http.server." + string(request.IDResponseCount):      i,
 			"http.server." + string(request.IDResponseValidCount): i,
@@ -170,6 +179,7 @@ func TestMonitoringHandler(t *testing.T) {
 
 			"http.server.request.duration": i,
 		})
+		monitoringtest.ExpectOtelMetrics(t, reader, expected)
 	})
 }
 

--- a/internal/beater/monitoringtest/opentelemetry.go
+++ b/internal/beater/monitoringtest/opentelemetry.go
@@ -19,7 +19,6 @@ package monitoringtest
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,21 +26,12 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-// ExpectOtelMetrics asserts that the gathered metric set is exactly
-// expectedMetrics: every gathered metric must be listed and match, and
-// every listed metric must be present in the gathered set.
-//
-// Tests that exercise eagerly-zero-initialized counters can pass
-// WithEagerPrefixes to declare the prefixes under which unlisted
-// counters are tolerated provided their value is 0; histograms and
-// non-zero counters under those prefixes still fail.
 func ExpectOtelMetrics(
 	t *testing.T,
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
-	opts ...ExpectOption,
 ) {
-	assertOtelMetrics(t, reader, expectedMetrics, true, false, opts...)
+	assertOtelMetrics(t, reader, expectedMetrics, true, false)
 }
 
 func ExpectContainOtelMetrics(
@@ -50,34 +40,6 @@ func ExpectContainOtelMetrics(
 	expectedMetrics map[string]any,
 ) {
 	assertOtelMetrics(t, reader, expectedMetrics, false, false)
-}
-
-// ExpectOption configures ExpectOtelMetrics.
-type ExpectOption func(*expectConfig)
-
-type expectConfig struct {
-	eagerPrefixes []string
-}
-
-// WithEagerPrefixes declares that the implementation eagerly
-// zero-initializes counters under the given metric-name prefixes. An
-// unlisted gathered counter whose name has one of these prefixes is
-// required to equal 0 (and is otherwise tolerated); histograms and
-// counters outside these prefixes still trigger "unexpected metric"
-// failures.
-func WithEagerPrefixes(prefixes ...string) ExpectOption {
-	return func(c *expectConfig) {
-		c.eagerPrefixes = append(c.eagerPrefixes, prefixes...)
-	}
-}
-
-func hasEagerPrefix(name string, prefixes []string) bool {
-	for _, p := range prefixes {
-		if strings.HasPrefix(name, p) {
-			return true
-		}
-	}
-	return false
 }
 
 func ExpectContainAndNotContainOtelMetrics(
@@ -103,11 +65,8 @@ func ExpectContainOtelMetricsKeys(t assert.TestingT, reader sdkmetric.Reader, ex
 // assertOtelMetrics gathers all the metrics from `reader` and asserts that the value of those gathered metrics
 // are equal to that specified in `expectedMetrics`.
 //
-// If `fullMatch` is true, every gathered metric must be listed in
-// `expectedMetrics` with a matching value, except counters whose name has
-// a prefix passed via WithEagerPrefixes — those are tolerated when
-// unlisted provided the value is 0. Otherwise, `expectedMetrics` only
-// needs to be a subset of the gathered metrics.
+// If `fullMatch` is true, all gathered metrics from `reader` must be found in `expectedMetrics` and vice versa.
+// Otherwise, `expectedMetrics` only need to be a subset of the gathered metrics.
 //
 // If `skipValAssert` is true, the value assertion will be skipped entirely i.e. only care about the metric keys.
 func assertOtelMetrics(
@@ -115,12 +74,7 @@ func assertOtelMetrics(
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
 	fullMatch, skipValAssert bool,
-	opts ...ExpectOption,
 ) []string {
-	var cfg expectConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
 	var rm metricdata.ResourceMetrics
 	assert.NoError(t, reader.Collect(context.Background(), &rm))
 
@@ -128,24 +82,58 @@ func assertOtelMetrics(
 	var foundMetrics []string
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			value, isHistogram, ok := scalarValue(m.Data)
-			if !ok {
-				continue
-			}
-			foundMetrics = append(foundMetrics, m.Name)
-			if skipValAssert {
-				continue
-			}
-			if expected, listed := expectedMetrics[m.Name]; listed {
-				assert.EqualValues(t, expected, value, m.Name)
-				continue
-			}
-			if fullMatch {
-				if !isHistogram && hasEagerPrefix(m.Name, cfg.eagerPrefixes) {
-					assert.EqualValues(t, 0, value, m.Name)
+			switch d := m.Data.(type) {
+			case metricdata.Gauge[int64]:
+				assert.Equal(t, 1, len(d.DataPoints))
+				foundMetrics = append(foundMetrics, m.Name)
+				if skipValAssert {
 					continue
 				}
-				assert.Fail(t, "unexpected metric", m.Name)
+
+				if v, ok := expectedMetrics[m.Name]; ok {
+					assert.EqualValues(t, v, d.DataPoints[0].Value, m.Name)
+				} else if fullMatch {
+					assert.Fail(t, "unexpected metric", m.Name)
+				}
+
+			case metricdata.Gauge[float64]:
+				assert.Equal(t, 1, len(d.DataPoints))
+				foundMetrics = append(foundMetrics, m.Name)
+				if skipValAssert {
+					continue
+				}
+
+				if v, ok := expectedMetrics[m.Name]; ok {
+					assert.EqualValues(t, v, d.DataPoints[0].Value, m.Name)
+				} else if fullMatch {
+					assert.Fail(t, "unexpected metric", m.Name)
+				}
+
+			case metricdata.Sum[int64]:
+				assert.Equal(t, 1, len(d.DataPoints))
+				foundMetrics = append(foundMetrics, m.Name)
+				if skipValAssert {
+					continue
+				}
+
+				if v, ok := expectedMetrics[m.Name]; ok {
+					assert.EqualValues(t, v, d.DataPoints[0].Value, m.Name)
+				} else if fullMatch {
+					assert.Fail(t, "unexpected metric", m.Name)
+				}
+
+			case metricdata.Histogram[int64]:
+				assert.Equal(t, 1, len(d.DataPoints))
+				foundMetrics = append(foundMetrics, m.Name)
+				if skipValAssert {
+					continue
+				}
+
+				if v, ok := expectedMetrics[m.Name]; ok {
+					assert.EqualValues(t, v, d.DataPoints[0].Count, m.Name)
+				} else if fullMatch {
+					assert.Fail(t, "unexpected metric", m.Name)
+				}
 			}
 		}
 	}
@@ -154,41 +142,10 @@ func assertOtelMetrics(
 	for k := range expectedMetrics {
 		expectedMetricsKeys = append(expectedMetricsKeys, k)
 	}
-	// Subset (every expected is in found) covers both modes: the
-	// per-metric "unexpected" check above already catches extras under
-	// fullMatch, modulo the eager-prefix tolerance.
-	assert.Subset(t, foundMetrics, expectedMetricsKeys)
-	return foundMetrics
-}
-
-// scalarValue extracts the assertable scalar from a metric aggregation:
-// the data-point value for gauges and sums, the data-point count for
-// histograms. Returns ok=false if the metric has 0 or >1 data points.
-// isHistogram is true when the value is a histogram observation count;
-// callers use it to skip "must be 0 if unlisted" rules that don't apply
-// to histograms.
-func scalarValue(data metricdata.Aggregation) (value any, isHistogram, ok bool) {
-	switch d := data.(type) {
-	case metricdata.Gauge[int64]:
-		if len(d.DataPoints) != 1 {
-			return nil, false, false
-		}
-		return d.DataPoints[0].Value, false, true
-	case metricdata.Gauge[float64]:
-		if len(d.DataPoints) != 1 {
-			return nil, false, false
-		}
-		return d.DataPoints[0].Value, false, true
-	case metricdata.Sum[int64]:
-		if len(d.DataPoints) != 1 {
-			return nil, false, false
-		}
-		return d.DataPoints[0].Value, false, true
-	case metricdata.Histogram[int64]:
-		if len(d.DataPoints) != 1 {
-			return nil, false, false
-		}
-		return d.DataPoints[0].Count, true, true
+	if fullMatch {
+		assert.ElementsMatch(t, foundMetrics, expectedMetricsKeys)
+	} else {
+		assert.Subset(t, foundMetrics, expectedMetricsKeys)
 	}
-	return nil, false, false
+	return foundMetrics
 }

--- a/internal/beater/monitoringtest/opentelemetry.go
+++ b/internal/beater/monitoringtest/opentelemetry.go
@@ -62,13 +62,23 @@ func ExpectContainOtelMetricsKeys(t assert.TestingT, reader sdkmetric.Reader, ex
 	assertOtelMetrics(t, reader, expectedMetrics, false, true)
 }
 
-// assertOtelMetrics gathers all the metrics from `reader` and asserts that the value of those gathered metrics
-// are equal to that specified in `expectedMetrics`.
+// assertOtelMetrics gathers all the metrics from `reader` and asserts that
+// each gathered metric matches `expectedMetrics`.
 //
-// If `fullMatch` is true, all gathered metrics from `reader` must be found in `expectedMetrics` and vice versa.
-// Otherwise, `expectedMetrics` only need to be a subset of the gathered metrics.
+// If `fullMatch` is true, every gathered counter / gauge / up-down counter
+// must either be listed in `expectedMetrics` with the matching value, or
+// implicitly equal 0; this is the natural pattern when using otelmetric
+// helpers that zero-init counters at construction. Histograms are skipped
+// from this rule because their "value" is an observation count and isn't
+// meaningfully comparable to 0; tests that care about histogram counts
+// must list them explicitly. `expectedMetrics` entries that don't appear
+// in the gathered set are treated as failures.
 //
-// If `skipValAssert` is true, the value assertion will be skipped entirely i.e. only care about the metric keys.
+// If `fullMatch` is false, `expectedMetrics` only needs to be a subset of
+// the gathered metrics.
+//
+// If `skipValAssert` is true, the value assertion is skipped entirely;
+// only the metric keys are checked.
 func assertOtelMetrics(
 	t assert.TestingT,
 	reader sdkmetric.Reader,
@@ -82,70 +92,64 @@ func assertOtelMetrics(
 	var foundMetrics []string
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			switch d := m.Data.(type) {
-			case metricdata.Gauge[int64]:
-				assert.Equal(t, 1, len(d.DataPoints))
-				foundMetrics = append(foundMetrics, m.Name)
-				if skipValAssert {
-					continue
-				}
-
-				if v, ok := expectedMetrics[m.Name]; ok {
-					assert.EqualValues(t, v, d.DataPoints[0].Value, m.Name)
-				} else if fullMatch {
-					assert.Fail(t, "unexpected metric", m.Name)
-				}
-
-			case metricdata.Gauge[float64]:
-				assert.Equal(t, 1, len(d.DataPoints))
-				foundMetrics = append(foundMetrics, m.Name)
-				if skipValAssert {
-					continue
-				}
-
-				if v, ok := expectedMetrics[m.Name]; ok {
-					assert.EqualValues(t, v, d.DataPoints[0].Value, m.Name)
-				} else if fullMatch {
-					assert.Fail(t, "unexpected metric", m.Name)
-				}
-
-			case metricdata.Sum[int64]:
-				assert.Equal(t, 1, len(d.DataPoints))
-				foundMetrics = append(foundMetrics, m.Name)
-				if skipValAssert {
-					continue
-				}
-
-				if v, ok := expectedMetrics[m.Name]; ok {
-					assert.EqualValues(t, v, d.DataPoints[0].Value, m.Name)
-				} else if fullMatch {
-					assert.Fail(t, "unexpected metric", m.Name)
-				}
-
-			case metricdata.Histogram[int64]:
-				assert.Equal(t, 1, len(d.DataPoints))
-				foundMetrics = append(foundMetrics, m.Name)
-				if skipValAssert {
-					continue
-				}
-
-				if v, ok := expectedMetrics[m.Name]; ok {
-					assert.EqualValues(t, v, d.DataPoints[0].Count, m.Name)
-				} else if fullMatch {
-					assert.Fail(t, "unexpected metric", m.Name)
-				}
+			value, isHistogram, ok := scalarValue(m.Data)
+			if !ok {
+				continue
+			}
+			foundMetrics = append(foundMetrics, m.Name)
+			if skipValAssert {
+				continue
+			}
+			if expected, listed := expectedMetrics[m.Name]; listed {
+				assert.EqualValues(t, expected, value, m.Name)
+			} else if fullMatch && !isHistogram {
+				assert.EqualValues(t, 0, value, m.Name)
 			}
 		}
 	}
 
-	var expectedMetricsKeys []string
-	for k := range expectedMetrics {
-		expectedMetricsKeys = append(expectedMetricsKeys, k)
-	}
 	if fullMatch {
-		assert.ElementsMatch(t, foundMetrics, expectedMetricsKeys)
+		// Catch the inverse: expected entries that didn't show up.
+		for k := range expectedMetrics {
+			assert.Contains(t, foundMetrics, k)
+		}
 	} else {
-		assert.Subset(t, foundMetrics, expectedMetricsKeys)
+		var expectedKeys []string
+		for k := range expectedMetrics {
+			expectedKeys = append(expectedKeys, k)
+		}
+		assert.Subset(t, foundMetrics, expectedKeys)
 	}
 	return foundMetrics
+}
+
+// scalarValue extracts a single scalar value from a metricdata.Aggregation
+// for assertion purposes. Histograms return their data point count and
+// isHistogram=true; gauges and sums return the data point value with
+// isHistogram=false. Anything with no data point or multiple data points
+// is skipped (ok=false).
+func scalarValue(data metricdata.Aggregation) (value any, isHistogram, ok bool) {
+	switch d := data.(type) {
+	case metricdata.Gauge[int64]:
+		if len(d.DataPoints) != 1 {
+			return nil, false, false
+		}
+		return d.DataPoints[0].Value, false, true
+	case metricdata.Gauge[float64]:
+		if len(d.DataPoints) != 1 {
+			return nil, false, false
+		}
+		return d.DataPoints[0].Value, false, true
+	case metricdata.Sum[int64]:
+		if len(d.DataPoints) != 1 {
+			return nil, false, false
+		}
+		return d.DataPoints[0].Value, false, true
+	case metricdata.Histogram[int64]:
+		if len(d.DataPoints) != 1 {
+			return nil, false, false
+		}
+		return d.DataPoints[0].Count, true, true
+	}
+	return nil, false, false
 }

--- a/internal/beater/monitoringtest/opentelemetry.go
+++ b/internal/beater/monitoringtest/opentelemetry.go
@@ -19,44 +19,29 @@ package monitoringtest
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-
-	"github.com/elastic/apm-server/internal/beater/request"
 )
 
 // ExpectOtelMetrics asserts that the gathered metric set is exactly
 // expectedMetrics: every gathered metric must be listed and match, and
-// every listed metric must be present in the gathered set. Tests that
-// exercise eagerly-zero-initialized counters (HTTP middleware, gRPC
-// interceptor) bootstrap their expectedMetrics map via EagerCountersZeros
-// so the noise floor is part of the asserted contract.
+// every listed metric must be present in the gathered set.
+//
+// Tests that exercise eagerly-zero-initialized counters can pass
+// WithEagerPrefixes to declare the prefixes under which unlisted
+// counters are tolerated provided their value is 0; histograms and
+// non-zero counters under those prefixes still fail.
 func ExpectOtelMetrics(
 	t *testing.T,
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
+	opts ...ExpectOption,
 ) {
-	assertOtelMetrics(t, reader, expectedMetrics, matchModeFull, false)
-}
-
-// ExpectOtelMetricsNonZero is a relaxation of ExpectOtelMetrics for tests
-// whose code path exercises a large set of eagerly-zero-initialized
-// counters that the test does not care to enumerate. Every listed metric
-// is asserted exactly; every unlisted gathered metric must equal 0
-// (histograms are exempt because their value is an observation count).
-// Use ExpectOtelMetrics when the test wants a strict "exactly these
-// metrics fired" contract; use this when the test only wants to assert
-// "these specific metrics fired with these values, and nothing else
-// surprising fired".
-func ExpectOtelMetricsNonZero(
-	t *testing.T,
-	reader sdkmetric.Reader,
-	expectedMetrics map[string]any,
-) {
-	assertOtelMetrics(t, reader, expectedMetrics, matchModeNonZero, false)
+	assertOtelMetrics(t, reader, expectedMetrics, true, false, opts...)
 }
 
 func ExpectContainOtelMetrics(
@@ -64,7 +49,35 @@ func ExpectContainOtelMetrics(
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
 ) {
-	assertOtelMetrics(t, reader, expectedMetrics, matchModeContain, false)
+	assertOtelMetrics(t, reader, expectedMetrics, false, false)
+}
+
+// ExpectOption configures ExpectOtelMetrics.
+type ExpectOption func(*expectConfig)
+
+type expectConfig struct {
+	eagerPrefixes []string
+}
+
+// WithEagerPrefixes declares that the implementation eagerly
+// zero-initializes counters under the given metric-name prefixes. An
+// unlisted gathered counter whose name has one of these prefixes is
+// required to equal 0 (and is otherwise tolerated); histograms and
+// counters outside these prefixes still trigger "unexpected metric"
+// failures.
+func WithEagerPrefixes(prefixes ...string) ExpectOption {
+	return func(c *expectConfig) {
+		c.eagerPrefixes = append(c.eagerPrefixes, prefixes...)
+	}
+}
+
+func hasEagerPrefix(name string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func ExpectContainAndNotContainOtelMetrics(
@@ -73,7 +86,7 @@ func ExpectContainAndNotContainOtelMetrics(
 	expectedMetrics map[string]any,
 	notExpectedMetricKeys []string,
 ) {
-	foundMetricKeys := assertOtelMetrics(t, reader, expectedMetrics, matchModeContain, false)
+	foundMetricKeys := assertOtelMetrics(t, reader, expectedMetrics, false, false)
 	for _, key := range notExpectedMetricKeys {
 		assert.NotContains(t, foundMetricKeys, key)
 	}
@@ -84,48 +97,30 @@ func ExpectContainOtelMetricsKeys(t assert.TestingT, reader sdkmetric.Reader, ex
 	for _, metricKey := range expectedMetricsKeys {
 		expectedMetrics[metricKey] = nil
 	}
-	assertOtelMetrics(t, reader, expectedMetrics, matchModeContain, true)
+	assertOtelMetrics(t, reader, expectedMetrics, false, true)
 }
 
-// EagerCountersZeros returns a map[name]int64(0) for every (prefix, id)
-// pair in `prefixes × ids`. Tests that exercise code paths with eagerly
-// zero-initialized counters use this to bootstrap their expected map for
-// ExpectOtelMetrics; the listed prefixes make the eager-init contract
-// part of the test, and any non-zero values are added by the caller via
-// map assignment after.
-func EagerCountersZeros(prefixes []string, ids []request.ResultID) map[string]any {
-	out := make(map[string]any, len(prefixes)*len(ids))
-	for _, p := range prefixes {
-		for _, id := range ids {
-			out[p+string(id)] = int64(0)
-		}
-	}
-	return out
-}
-
-type matchMode int
-
-const (
-	// matchModeFull: gathered ≡ expected (set equality with values).
-	matchModeFull matchMode = iota
-	// matchModeNonZero: every listed metric matches, every unlisted
-	// gathered metric must equal 0 (histograms exempt).
-	matchModeNonZero
-	// matchModeContain: expected is a subset of gathered.
-	matchModeContain
-)
-
-// assertOtelMetrics gathers metrics from `reader` and asserts they match
-// `expectedMetrics` according to `mode`.
+// assertOtelMetrics gathers all the metrics from `reader` and asserts that the value of those gathered metrics
+// are equal to that specified in `expectedMetrics`.
 //
-// If `skipValAssert` is true, only the metric keys are checked.
+// If `fullMatch` is true, every gathered metric must be listed in
+// `expectedMetrics` with a matching value, except counters whose name has
+// a prefix passed via WithEagerPrefixes — those are tolerated when
+// unlisted provided the value is 0. Otherwise, `expectedMetrics` only
+// needs to be a subset of the gathered metrics.
+//
+// If `skipValAssert` is true, the value assertion will be skipped entirely i.e. only care about the metric keys.
 func assertOtelMetrics(
 	t assert.TestingT,
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
-	mode matchMode,
-	skipValAssert bool,
+	fullMatch, skipValAssert bool,
+	opts ...ExpectOption,
 ) []string {
+	var cfg expectConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	var rm metricdata.ResourceMetrics
 	assert.NoError(t, reader.Collect(context.Background(), &rm))
 
@@ -145,27 +140,24 @@ func assertOtelMetrics(
 				assert.EqualValues(t, expected, value, m.Name)
 				continue
 			}
-			switch mode {
-			case matchModeFull:
-				assert.Fail(t, "unexpected metric", m.Name)
-			case matchModeNonZero:
-				if !isHistogram {
+			if fullMatch {
+				if !isHistogram && hasEagerPrefix(m.Name, cfg.eagerPrefixes) {
 					assert.EqualValues(t, 0, value, m.Name)
+					continue
 				}
+				assert.Fail(t, "unexpected metric", m.Name)
 			}
 		}
 	}
 
-	expectedKeys := make([]string, 0, len(expectedMetrics))
+	var expectedMetricsKeys []string
 	for k := range expectedMetrics {
-		expectedKeys = append(expectedKeys, k)
+		expectedMetricsKeys = append(expectedMetricsKeys, k)
 	}
-	switch mode {
-	case matchModeFull:
-		assert.ElementsMatch(t, foundMetrics, expectedKeys)
-	case matchModeNonZero, matchModeContain:
-		assert.Subset(t, foundMetrics, expectedKeys)
-	}
+	// Subset (every expected is in found) covers both modes: the
+	// per-metric "unexpected" check above already catches extras under
+	// fullMatch, modulo the eager-prefix tolerance.
+	assert.Subset(t, foundMetrics, expectedMetricsKeys)
 	return foundMetrics
 }
 

--- a/internal/beater/monitoringtest/opentelemetry.go
+++ b/internal/beater/monitoringtest/opentelemetry.go
@@ -24,14 +24,39 @@ import (
 	"github.com/stretchr/testify/assert"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/elastic/apm-server/internal/beater/request"
 )
 
+// ExpectOtelMetrics asserts that the gathered metric set is exactly
+// expectedMetrics: every gathered metric must be listed and match, and
+// every listed metric must be present in the gathered set. Tests that
+// exercise eagerly-zero-initialized counters (HTTP middleware, gRPC
+// interceptor) bootstrap their expectedMetrics map via EagerCountersZeros
+// so the noise floor is part of the asserted contract.
 func ExpectOtelMetrics(
 	t *testing.T,
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
 ) {
-	assertOtelMetrics(t, reader, expectedMetrics, true, false)
+	assertOtelMetrics(t, reader, expectedMetrics, matchModeFull, false)
+}
+
+// ExpectOtelMetricsNonZero is a relaxation of ExpectOtelMetrics for tests
+// whose code path exercises a large set of eagerly-zero-initialized
+// counters that the test does not care to enumerate. Every listed metric
+// is asserted exactly; every unlisted gathered metric must equal 0
+// (histograms are exempt because their value is an observation count).
+// Use ExpectOtelMetrics when the test wants a strict "exactly these
+// metrics fired" contract; use this when the test only wants to assert
+// "these specific metrics fired with these values, and nothing else
+// surprising fired".
+func ExpectOtelMetricsNonZero(
+	t *testing.T,
+	reader sdkmetric.Reader,
+	expectedMetrics map[string]any,
+) {
+	assertOtelMetrics(t, reader, expectedMetrics, matchModeNonZero, false)
 }
 
 func ExpectContainOtelMetrics(
@@ -39,7 +64,7 @@ func ExpectContainOtelMetrics(
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
 ) {
-	assertOtelMetrics(t, reader, expectedMetrics, false, false)
+	assertOtelMetrics(t, reader, expectedMetrics, matchModeContain, false)
 }
 
 func ExpectContainAndNotContainOtelMetrics(
@@ -48,7 +73,7 @@ func ExpectContainAndNotContainOtelMetrics(
 	expectedMetrics map[string]any,
 	notExpectedMetricKeys []string,
 ) {
-	foundMetricKeys := assertOtelMetrics(t, reader, expectedMetrics, false, false)
+	foundMetricKeys := assertOtelMetrics(t, reader, expectedMetrics, matchModeContain, false)
 	for _, key := range notExpectedMetricKeys {
 		assert.NotContains(t, foundMetricKeys, key)
 	}
@@ -59,31 +84,47 @@ func ExpectContainOtelMetricsKeys(t assert.TestingT, reader sdkmetric.Reader, ex
 	for _, metricKey := range expectedMetricsKeys {
 		expectedMetrics[metricKey] = nil
 	}
-	assertOtelMetrics(t, reader, expectedMetrics, false, true)
+	assertOtelMetrics(t, reader, expectedMetrics, matchModeContain, true)
 }
 
-// assertOtelMetrics gathers all the metrics from `reader` and asserts that
-// each gathered metric matches `expectedMetrics`.
+// EagerCountersZeros returns a map[name]int64(0) for every (prefix, id)
+// pair in `prefixes × ids`. Tests that exercise code paths with eagerly
+// zero-initialized counters use this to bootstrap their expected map for
+// ExpectOtelMetrics; the listed prefixes make the eager-init contract
+// part of the test, and any non-zero values are added by the caller via
+// map assignment after.
+func EagerCountersZeros(prefixes []string, ids []request.ResultID) map[string]any {
+	out := make(map[string]any, len(prefixes)*len(ids))
+	for _, p := range prefixes {
+		for _, id := range ids {
+			out[p+string(id)] = int64(0)
+		}
+	}
+	return out
+}
+
+type matchMode int
+
+const (
+	// matchModeFull: gathered ≡ expected (set equality with values).
+	matchModeFull matchMode = iota
+	// matchModeNonZero: every listed metric matches, every unlisted
+	// gathered metric must equal 0 (histograms exempt).
+	matchModeNonZero
+	// matchModeContain: expected is a subset of gathered.
+	matchModeContain
+)
+
+// assertOtelMetrics gathers metrics from `reader` and asserts they match
+// `expectedMetrics` according to `mode`.
 //
-// If `fullMatch` is true, every gathered counter / gauge / up-down counter
-// must either be listed in `expectedMetrics` with the matching value, or
-// implicitly equal 0; this is the natural pattern when using otelmetric
-// helpers that zero-init counters at construction. Histograms are skipped
-// from this rule because their "value" is an observation count and isn't
-// meaningfully comparable to 0; tests that care about histogram counts
-// must list them explicitly. `expectedMetrics` entries that don't appear
-// in the gathered set are treated as failures.
-//
-// If `fullMatch` is false, `expectedMetrics` only needs to be a subset of
-// the gathered metrics.
-//
-// If `skipValAssert` is true, the value assertion is skipped entirely;
-// only the metric keys are checked.
+// If `skipValAssert` is true, only the metric keys are checked.
 func assertOtelMetrics(
 	t assert.TestingT,
 	reader sdkmetric.Reader,
 	expectedMetrics map[string]any,
-	fullMatch, skipValAssert bool,
+	mode matchMode,
+	skipValAssert bool,
 ) []string {
 	var rm metricdata.ResourceMetrics
 	assert.NoError(t, reader.Collect(context.Background(), &rm))
@@ -102,32 +143,38 @@ func assertOtelMetrics(
 			}
 			if expected, listed := expectedMetrics[m.Name]; listed {
 				assert.EqualValues(t, expected, value, m.Name)
-			} else if fullMatch && !isHistogram {
-				assert.EqualValues(t, 0, value, m.Name)
+				continue
+			}
+			switch mode {
+			case matchModeFull:
+				assert.Fail(t, "unexpected metric", m.Name)
+			case matchModeNonZero:
+				if !isHistogram {
+					assert.EqualValues(t, 0, value, m.Name)
+				}
 			}
 		}
 	}
 
-	if fullMatch {
-		// Catch the inverse: expected entries that didn't show up.
-		for k := range expectedMetrics {
-			assert.Contains(t, foundMetrics, k)
-		}
-	} else {
-		var expectedKeys []string
-		for k := range expectedMetrics {
-			expectedKeys = append(expectedKeys, k)
-		}
+	expectedKeys := make([]string, 0, len(expectedMetrics))
+	for k := range expectedMetrics {
+		expectedKeys = append(expectedKeys, k)
+	}
+	switch mode {
+	case matchModeFull:
+		assert.ElementsMatch(t, foundMetrics, expectedKeys)
+	case matchModeNonZero, matchModeContain:
 		assert.Subset(t, foundMetrics, expectedKeys)
 	}
 	return foundMetrics
 }
 
-// scalarValue extracts a single scalar value from a metricdata.Aggregation
-// for assertion purposes. Histograms return their data point count and
-// isHistogram=true; gauges and sums return the data point value with
-// isHistogram=false. Anything with no data point or multiple data points
-// is skipped (ok=false).
+// scalarValue extracts the assertable scalar from a metric aggregation:
+// the data-point value for gauges and sums, the data-point count for
+// histograms. Returns ok=false if the metric has 0 or >1 data points.
+// isHistogram is true when the value is a histogram observation count;
+// callers use it to skip "must be 0 if unlisted" rules that don't apply
+// to histograms.
 func scalarValue(data metricdata.Aggregation) (value any, isHistogram, ok bool) {
 	switch d := data.(type) {
 	case metricdata.Gauge[int64]:

--- a/internal/beater/otlp/grpc.go
+++ b/internal/beater/otlp/grpc.go
@@ -73,10 +73,7 @@ func RegisterGRPCServices(
 		_ = unsupportedGRPCMetricRegistration.Unregister()
 	}
 	unsupportedGRPCMetricRegistration, _ = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		stats := consumer.Stats()
-		if stats.UnsupportedMetricsDropped > 0 {
-			o.ObserveInt64(grpcMetricsConsumerUnsupportedDropped, stats.UnsupportedMetricsDropped)
-		}
+		o.ObserveInt64(grpcMetricsConsumerUnsupportedDropped, consumer.Stats().UnsupportedMetricsDropped)
 		return nil
 	}, grpcMetricsConsumerUnsupportedDropped)
 

--- a/internal/beater/otlp/grpc_test.go
+++ b/internal/beater/otlp/grpc_test.go
@@ -88,7 +88,7 @@ func TestConsumeTracesGRPC(t *testing.T) {
 	assert.Len(t, batches[0], 1)
 	assert.Len(t, batches[1], 1)
 
-	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
 		"grpc.server.request.count":                         2,
 		"grpc.server.response.valid.count":                  1,
 		"grpc.server.response.count":                        2,
@@ -137,7 +137,7 @@ func TestConsumeMetricsGRPC(t *testing.T) {
 	errStatus := status.Convert(err)
 	assert.Equal(t, "failed to publish events", errStatus.Message())
 
-	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
 		"grpc.server.request.count":                          2,
 		"grpc.server.response.valid.count":                   1,
 		"grpc.server.response.count":                         2,
@@ -188,7 +188,7 @@ func TestConsumeLogsGRPC(t *testing.T) {
 	assert.Len(t, batches[0], 1)
 	assert.Len(t, batches[1], 1)
 
-	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
 		"grpc.server.request.count":                       2,
 		"grpc.server.response.valid.count":                1,
 		"grpc.server.response.count":                      2,

--- a/internal/beater/otlp/grpc_test.go
+++ b/internal/beater/otlp/grpc_test.go
@@ -88,7 +88,7 @@ func TestConsumeTracesGRPC(t *testing.T) {
 	assert.Len(t, batches[0], 1)
 	assert.Len(t, batches[1], 1)
 
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
+	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
 		"grpc.server.request.count":                         2,
 		"grpc.server.response.valid.count":                  1,
 		"grpc.server.response.count":                        2,
@@ -137,7 +137,7 @@ func TestConsumeMetricsGRPC(t *testing.T) {
 	errStatus := status.Convert(err)
 	assert.Equal(t, "failed to publish events", errStatus.Message())
 
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
+	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
 		"grpc.server.request.count":                          2,
 		"grpc.server.response.valid.count":                   1,
 		"grpc.server.response.count":                         2,
@@ -188,7 +188,7 @@ func TestConsumeLogsGRPC(t *testing.T) {
 	assert.Len(t, batches[0], 1)
 	assert.Len(t, batches[1], 1)
 
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
+	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
 		"grpc.server.request.count":                       2,
 		"grpc.server.response.valid.count":                1,
 		"grpc.server.response.count":                      2,

--- a/internal/beater/otlp/grpc_test.go
+++ b/internal/beater/otlp/grpc_test.go
@@ -88,7 +88,11 @@ func TestConsumeTracesGRPC(t *testing.T) {
 	assert.Len(t, batches[0], 1)
 	assert.Len(t, batches[1], 1)
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+		"grpc.server.request.count":                         2,
+		"grpc.server.response.valid.count":                  1,
+		"grpc.server.response.count":                        2,
+		"grpc.server.response.errors.count":                 1,
 		"apm-server.otlp.grpc.traces.request.count":         2,
 		"apm-server.otlp.grpc.traces.response.valid.count":  1,
 		"apm-server.otlp.grpc.traces.response.count":        2,
@@ -133,7 +137,11 @@ func TestConsumeMetricsGRPC(t *testing.T) {
 	errStatus := status.Convert(err)
 	assert.Equal(t, "failed to publish events", errStatus.Message())
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+		"grpc.server.request.count":                          2,
+		"grpc.server.response.valid.count":                   1,
+		"grpc.server.response.count":                         2,
+		"grpc.server.response.errors.count":                  1,
 		"apm-server.otlp.grpc.metrics.request.count":         2,
 		"apm-server.otlp.grpc.metrics.response.valid.count":  1,
 		"apm-server.otlp.grpc.metrics.response.count":        2,
@@ -180,7 +188,11 @@ func TestConsumeLogsGRPC(t *testing.T) {
 	assert.Len(t, batches[0], 1)
 	assert.Len(t, batches[1], 1)
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+		"grpc.server.request.count":                       2,
+		"grpc.server.response.valid.count":                1,
+		"grpc.server.response.count":                      2,
+		"grpc.server.response.errors.count":               1,
 		"apm-server.otlp.grpc.logs.request.count":         2,
 		"apm-server.otlp.grpc.logs.response.valid.count":  1,
 		"apm-server.otlp.grpc.logs.response.count":        2,

--- a/internal/beater/otlp/http.go
+++ b/internal/beater/otlp/http.go
@@ -71,10 +71,7 @@ func NewHTTPHandlers(logger *zap.Logger, processor modelpb.BatchProcessor, semap
 		_ = unsupportedHTTPMetricRegistration.Unregister()
 	}
 	unsupportedHTTPMetricRegistration, _ = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		stats := consumer.Stats()
-		if stats.UnsupportedMetricsDropped > 0 {
-			o.ObserveInt64(httpMetricsConsumerUnsupportedDropped, stats.UnsupportedMetricsDropped)
-		}
+		o.ObserveInt64(httpMetricsConsumerUnsupportedDropped, consumer.Stats().UnsupportedMetricsDropped)
 		return nil
 	}, httpMetricsConsumerUnsupportedDropped)
 

--- a/internal/beater/otlp/http_test.go
+++ b/internal/beater/otlp/http_test.go
@@ -80,10 +80,15 @@ func TestConsumeTracesHTTP(t *testing.T) {
 	require.Len(t, batches, 1)
 	assert.Len(t, batches[0], 1)
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
-		"http.server.request.count":        1,
-		"http.server.response.count":       1,
-		"http.server.response.valid.count": 1,
+	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+		"http.server.request.count":                        1,
+		"http.server.response.count":                       1,
+		"http.server.response.valid.count":                 1,
+		"http.server.unset":                                1,
+		"apm-server.otlp.http.traces.request.count":        1,
+		"apm-server.otlp.http.traces.response.count":       1,
+		"apm-server.otlp.http.traces.response.valid.count": 1,
+		"apm-server.otlp.http.traces.unset":                1,
 	})
 
 }
@@ -117,10 +122,15 @@ func TestConsumeMetricsHTTP(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, rsp.Body.Close())
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
-		"http.server.request.count":        1,
-		"http.server.response.count":       1,
-		"http.server.response.valid.count": 1,
+	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+		"http.server.request.count":                         1,
+		"http.server.response.count":                        1,
+		"http.server.response.valid.count":                  1,
+		"http.server.unset":                                 1,
+		"apm-server.otlp.http.metrics.request.count":        1,
+		"apm-server.otlp.http.metrics.response.count":       1,
+		"apm-server.otlp.http.metrics.response.valid.count": 1,
+		"apm-server.otlp.http.metrics.unset":                1,
 	})
 }
 
@@ -153,10 +163,15 @@ func TestConsumeLogsHTTP(t *testing.T) {
 	assert.NoError(t, rsp.Body.Close())
 	require.Len(t, batches, 1)
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
-		"http.server.request.count":        1,
-		"http.server.response.count":       1,
-		"http.server.response.valid.count": 1,
+	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+		"http.server.request.count":                      1,
+		"http.server.response.count":                     1,
+		"http.server.response.valid.count":               1,
+		"http.server.unset":                              1,
+		"apm-server.otlp.http.logs.request.count":        1,
+		"apm-server.otlp.http.logs.response.count":       1,
+		"apm-server.otlp.http.logs.response.valid.count": 1,
+		"apm-server.otlp.http.logs.unset":                1,
 	})
 }
 

--- a/internal/beater/otlp/http_test.go
+++ b/internal/beater/otlp/http_test.go
@@ -80,7 +80,7 @@ func TestConsumeTracesHTTP(t *testing.T) {
 	require.Len(t, batches, 1)
 	assert.Len(t, batches[0], 1)
 
-	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
 		"http.server.request.count":                        1,
 		"http.server.response.count":                       1,
 		"http.server.response.valid.count":                 1,
@@ -122,7 +122,7 @@ func TestConsumeMetricsHTTP(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, rsp.Body.Close())
 
-	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
 		"http.server.request.count":                         1,
 		"http.server.response.count":                        1,
 		"http.server.response.valid.count":                  1,
@@ -163,7 +163,7 @@ func TestConsumeLogsHTTP(t *testing.T) {
 	assert.NoError(t, rsp.Body.Close())
 	require.Len(t, batches, 1)
 
-	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
 		"http.server.request.count":                      1,
 		"http.server.response.count":                     1,
 		"http.server.response.valid.count":               1,

--- a/internal/beater/otlp/http_test.go
+++ b/internal/beater/otlp/http_test.go
@@ -80,7 +80,7 @@ func TestConsumeTracesHTTP(t *testing.T) {
 	require.Len(t, batches, 1)
 	assert.Len(t, batches[0], 1)
 
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
+	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
 		"http.server.request.count":                        1,
 		"http.server.response.count":                       1,
 		"http.server.response.valid.count":                 1,
@@ -122,7 +122,7 @@ func TestConsumeMetricsHTTP(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, rsp.Body.Close())
 
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
+	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
 		"http.server.request.count":                         1,
 		"http.server.response.count":                        1,
 		"http.server.response.valid.count":                  1,
@@ -163,7 +163,7 @@ func TestConsumeLogsHTTP(t *testing.T) {
 	assert.NoError(t, rsp.Body.Close())
 	require.Len(t, batches, 1)
 
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
+	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
 		"http.server.request.count":                      1,
 		"http.server.response.count":                     1,
 		"http.server.response.valid.count":               1,

--- a/internal/beater/request/result.go
+++ b/internal/beater/request/result.go
@@ -109,6 +109,13 @@ var (
 	// The set is the IDs the middleware unconditionally increments per
 	// request, plus every key in MapResultIDToStatus (anything c.Result.ID
 	// can be set to). Treat as read-only.
+	//
+	// Drift contract: any new ResultID passed to a monitoring counter
+	// (middleware/monitoring_middleware.go, interceptors/metrics.go) must
+	// be reachable from this list. HTTP-status-mapped IDs go in
+	// MapResultIDToStatus and are picked up automatically. IDs that are
+	// not status-mapped (incremented unconditionally) must be appended to
+	// the literal slice below.
 	AllResultIDs = func() []ResultID {
 		ids := []ResultID{
 			IDUnset,

--- a/internal/beater/request/result.go
+++ b/internal/beater/request/result.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-
 	// IDUnset identifies requests not covered by other IDs
 	IDUnset ResultID = "unset"
 
@@ -36,10 +35,6 @@ const (
 	IDResponseErrorsCount ResultID = "response.errors.count"
 	// IDResponseValidCount identifies all successful responses
 	IDResponseValidCount ResultID = "response.valid.count"
-	// IDEventReceivedCount identifies amount of received events
-	IDEventReceivedCount ResultID = "event.received.count"
-	// IDEventDroppedCount identifies amount of dropped events
-	IDEventDroppedCount ResultID = "event.dropped.count"
 
 	// IDResponseValidNotModified identifies all successful responses without a modified body
 	IDResponseValidNotModified ResultID = "response.valid.notmodified"
@@ -78,58 +73,56 @@ const (
 	IDResponseErrorsInternal ResultID = "response.errors.internal"
 )
 
-var (
-	// MapResultIDToStatus takes a ResultID and maps it to a status
-	MapResultIDToStatus = map[ResultID]Status{
-		IDResponseValidOK:                  {Code: http.StatusOK, Keyword: "request ok"},
-		IDResponseValidAccepted:            {Code: http.StatusAccepted, Keyword: "request accepted"},
-		IDResponseValidNotModified:         {Code: http.StatusNotModified, Keyword: "not modified"},
-		IDResponseErrorsForbidden:          {Code: http.StatusForbidden, Keyword: "forbidden request"},
-		IDResponseErrorsUnauthorized:       {Code: http.StatusUnauthorized, Keyword: "unauthorized"},
-		IDResponseErrorsNotFound:           {Code: http.StatusNotFound, Keyword: "404 page not found"},
-		IDResponseErrorsRequestTooLarge:    {Code: http.StatusRequestEntityTooLarge, Keyword: "request body too large"},
-		IDResponseErrorsInvalidQuery:       {Code: http.StatusBadRequest, Keyword: "invalid query"},
-		IDResponseErrorsDecode:             {Code: http.StatusBadRequest, Keyword: "data decoding error"},
-		IDResponseErrorsValidate:           {Code: http.StatusBadRequest, Keyword: "data validation error"},
-		IDResponseErrorsMethodNotAllowed:   {Code: http.StatusMethodNotAllowed, Keyword: "method not supported"},
-		IDResponseErrorsRateLimit:          {Code: http.StatusTooManyRequests, Keyword: "too many requests"},
-		IDResponseErrorsTimeout:            {Code: http.StatusServiceUnavailable, Keyword: "request timed out"},
-		IDResponseErrorsFullQueue:          {Code: http.StatusServiceUnavailable, Keyword: "queue is full"},
-		IDResponseErrorsShuttingDown:       {Code: http.StatusServiceUnavailable, Keyword: "server is shutting down"},
-		IDResponseErrorsServiceUnavailable: {Code: http.StatusServiceUnavailable, Keyword: "service unavailable"},
-		IDResponseErrorsInternal:           {Code: http.StatusInternalServerError, Keyword: "internal error"},
-	}
+// resultIDStatus maps each ResultID to its Status. Entries with a
+// zero-valued Status (no HTTP code) are IDs the middleware increments
+// unconditionally; entries with a Status are the values c.Result.ID can
+// be set to. This is the single source of truth: AllResultIDs and
+// MapResultIDToStatus are derived from it in init() below, so adding a
+// new ResultID is one new entry here.
+var resultIDStatus = map[ResultID]Status{
+	IDUnset:               {},
+	IDRequestCount:        {},
+	IDResponseCount:       {},
+	IDResponseErrorsCount: {},
+	IDResponseValidCount:  {},
 
-	// AllResultIDs is the canonical list of every ResultID the monitoring
-	// middleware records. It is used to eagerly register the corresponding
-	// counters at startup so the /stats endpoint enumerates each metric
-	// from process start, even before any request has produced that
-	// particular result.
-	//
-	// The set is the IDs the middleware unconditionally increments per
-	// request, plus every key in MapResultIDToStatus (anything c.Result.ID
-	// can be set to). Treat as read-only.
-	//
-	// Drift contract: any new ResultID passed to a monitoring counter
-	// (middleware/monitoring_middleware.go, interceptors/metrics.go) must
-	// be reachable from this list. HTTP-status-mapped IDs go in
-	// MapResultIDToStatus and are picked up automatically. IDs that are
-	// not status-mapped (incremented unconditionally) must be appended to
-	// the literal slice below.
-	AllResultIDs = func() []ResultID {
-		ids := []ResultID{
-			IDUnset,
-			IDRequestCount,
-			IDResponseCount,
-			IDResponseErrorsCount,
-			IDResponseValidCount,
+	IDResponseValidNotModified:         {Code: http.StatusNotModified, Keyword: "not modified"},
+	IDResponseValidOK:                  {Code: http.StatusOK, Keyword: "request ok"},
+	IDResponseValidAccepted:            {Code: http.StatusAccepted, Keyword: "request accepted"},
+	IDResponseErrorsForbidden:          {Code: http.StatusForbidden, Keyword: "forbidden request"},
+	IDResponseErrorsUnauthorized:       {Code: http.StatusUnauthorized, Keyword: "unauthorized"},
+	IDResponseErrorsNotFound:           {Code: http.StatusNotFound, Keyword: "404 page not found"},
+	IDResponseErrorsInvalidQuery:       {Code: http.StatusBadRequest, Keyword: "invalid query"},
+	IDResponseErrorsRequestTooLarge:    {Code: http.StatusRequestEntityTooLarge, Keyword: "request body too large"},
+	IDResponseErrorsDecode:             {Code: http.StatusBadRequest, Keyword: "data decoding error"},
+	IDResponseErrorsValidate:           {Code: http.StatusBadRequest, Keyword: "data validation error"},
+	IDResponseErrorsRateLimit:          {Code: http.StatusTooManyRequests, Keyword: "too many requests"},
+	IDResponseErrorsTimeout:            {Code: http.StatusServiceUnavailable, Keyword: "request timed out"},
+	IDResponseErrorsMethodNotAllowed:   {Code: http.StatusMethodNotAllowed, Keyword: "method not supported"},
+	IDResponseErrorsFullQueue:          {Code: http.StatusServiceUnavailable, Keyword: "queue is full"},
+	IDResponseErrorsShuttingDown:       {Code: http.StatusServiceUnavailable, Keyword: "server is shutting down"},
+	IDResponseErrorsServiceUnavailable: {Code: http.StatusServiceUnavailable, Keyword: "service unavailable"},
+	IDResponseErrorsInternal:           {Code: http.StatusInternalServerError, Keyword: "internal error"},
+}
+
+// AllResultIDs is the canonical list of every defined ResultID. It is
+// populated by init() from resultIDStatus above; tests and the
+// monitoring middleware/interceptor iterate it to eagerly register
+// every counter at startup. Treat as read-only after package init.
+var AllResultIDs []ResultID
+
+// MapResultIDToStatus is the subset of resultIDStatus with non-zero
+// Status (every ID c.Result.ID can be set to). Populated by init().
+var MapResultIDToStatus = map[ResultID]Status{}
+
+func init() {
+	for id, status := range resultIDStatus {
+		AllResultIDs = append(AllResultIDs, id)
+		if status.Code != 0 {
+			MapResultIDToStatus[id] = status
 		}
-		for id := range MapResultIDToStatus {
-			ids = append(ids, id)
-		}
-		return ids
-	}()
-)
+	}
+}
 
 // ResultID unique string identifying a requests Result
 type ResultID string

--- a/internal/beater/request/result.go
+++ b/internal/beater/request/result.go
@@ -99,6 +99,29 @@ var (
 		IDResponseErrorsServiceUnavailable: {Code: http.StatusServiceUnavailable, Keyword: "service unavailable"},
 		IDResponseErrorsInternal:           {Code: http.StatusInternalServerError, Keyword: "internal error"},
 	}
+
+	// AllResultIDs is the canonical list of every ResultID the monitoring
+	// middleware records. It is used to eagerly register the corresponding
+	// counters at startup so the /stats endpoint enumerates each metric
+	// from process start, even before any request has produced that
+	// particular result.
+	//
+	// The set is the IDs the middleware unconditionally increments per
+	// request, plus every key in MapResultIDToStatus (anything c.Result.ID
+	// can be set to). Treat as read-only.
+	AllResultIDs = func() []ResultID {
+		ids := []ResultID{
+			IDUnset,
+			IDRequestCount,
+			IDResponseCount,
+			IDResponseErrorsCount,
+			IDResponseValidCount,
+		}
+		for id := range MapResultIDToStatus {
+			ids = append(ids, id)
+		}
+		return ids
+	}()
 )
 
 // ResultID unique string identifying a requests Result

--- a/internal/model/modelprocessor/eventcounter.go
+++ b/internal/model/modelprocessor/eventcounter.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-server/internal/otelmetric"
 )
 
 // EventCounter is a model.BatchProcessor that counts the number of events processed,
@@ -44,10 +45,10 @@ func NewEventCounter(mp metric.MeterProvider) *EventCounter {
 	c := &EventCounter{}
 	for i := range c.eventCounters {
 		eventType := modelpb.APMEventType(i)
-		counter, _ := meter.Int64Counter(
+		c.eventCounters[i] = otelmetric.NewInt64Counter(
+			meter,
 			fmt.Sprintf("apm-server.processor.%s.transformations", eventType),
 		)
-		c.eventCounters[i] = counter
 	}
 	return c
 }

--- a/internal/model/modelprocessor/eventcounter_test.go
+++ b/internal/model/modelprocessor/eventcounter_test.go
@@ -49,7 +49,7 @@ func TestEventCounter(t *testing.T) {
 	err := processor.ProcessBatch(context.Background(), &batch)
 	assert.NoError(t, err)
 
-	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
 		"apm-server.processor.span.transformations":        1,
 		"apm-server.processor.transaction.transformations": 2,
 		// the empty event {} maps to APMEventType 0 ("undefined").

--- a/internal/model/modelprocessor/eventcounter_test.go
+++ b/internal/model/modelprocessor/eventcounter_test.go
@@ -49,8 +49,10 @@ func TestEventCounter(t *testing.T) {
 	err := processor.ProcessBatch(context.Background(), &batch)
 	assert.NoError(t, err)
 
-	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
+	monitoringtest.ExpectOtelMetrics(t, reader, map[string]any{
 		"apm-server.processor.span.transformations":        1,
 		"apm-server.processor.transaction.transformations": 2,
+		// the empty event {} maps to APMEventType 0 ("undefined").
+		"apm-server.processor.undefined.transformations": 1,
 	})
 }

--- a/internal/model/modelprocessor/eventcounter_test.go
+++ b/internal/model/modelprocessor/eventcounter_test.go
@@ -49,7 +49,7 @@ func TestEventCounter(t *testing.T) {
 	err := processor.ProcessBatch(context.Background(), &batch)
 	assert.NoError(t, err)
 
-	monitoringtest.ExpectOtelMetricsNonZero(t, reader, map[string]any{
+	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
 		"apm-server.processor.span.transformations":        1,
 		"apm-server.processor.transaction.transformations": 2,
 		// the empty event {} maps to APMEventType 0 ("undefined").

--- a/internal/otelmetric/instrument.go
+++ b/internal/otelmetric/instrument.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package otelmetric provides thin wrappers around OpenTelemetry metric
+// instrument constructors that record a zero data point at creation time.
+//
+// OTel only emits an instrument's value once it has at least one observed
+// data point. For long-tail counters (rare error paths, conditional
+// features) that means /stats won't list them until the relevant code
+// path has fired at least once. Adding zero to each counter at
+// construction makes the instrument enumerable by /stats from process
+// start, so downstream tooling that consumes /stats as a metric
+// definition (metricbeat field mappings, monitoring templates,
+// integration packages) sees a stable shape regardless of runtime
+// traffic.
+//
+// Only counter-shaped instruments are wrapped here. Adding zero to a
+// counter is a semantic no-op, so the eager registration is always
+// correct. Gauges, by contrast, represent a *current* value: recording
+// zero would falsely declare "the current value is 0" until something
+// records a real one. Histograms record observations, so an eager zero
+// would inflate observation counts. Callers needing those instrument
+// kinds should construct them directly and decide on their own initial
+// value (or rely on a periodic reporter to fill them in).
+//
+// The error returned by the underlying constructors is intentionally
+// dropped: it only surfaces invalid instrument names, which is a static
+// programmer error rather than a runtime condition.
+package otelmetric
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+// NewInt64Counter creates an Int64Counter and adds 0 once so the
+// instrument is enumerated by exporters from process start.
+func NewInt64Counter(meter metric.Meter, name string, options ...metric.Int64CounterOption) metric.Int64Counter {
+	c, _ := meter.Int64Counter(name, options...)
+	c.Add(context.Background(), 0)
+	return c
+}
+
+// NewInt64UpDownCounter creates an Int64UpDownCounter and adds 0 once so
+// the instrument is enumerated by exporters from process start.
+func NewInt64UpDownCounter(meter metric.Meter, name string, options ...metric.Int64UpDownCounterOption) metric.Int64UpDownCounter {
+	c, _ := meter.Int64UpDownCounter(name, options...)
+	c.Add(context.Background(), 0)
+	return c
+}

--- a/internal/otelmetric/instrument_test.go
+++ b/internal/otelmetric/instrument_test.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package otelmetric_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/elastic/apm-server/internal/otelmetric"
+)
+
+// TestEagerEmit verifies that the wrapper constructors emit each instrument
+// even when nothing has explicitly observed a value, which is the property
+// downstream tooling depends on to enumerate /stats as a metric definition.
+func TestEagerEmit(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("test")
+
+	otelmetric.NewInt64Counter(meter, "test.counter")
+	otelmetric.NewInt64UpDownCounter(meter, "test.updown")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	got := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if d, ok := m.Data.(metricdata.Sum[int64]); ok {
+				require.Len(t, d.DataPoints, 1, m.Name)
+				got[m.Name] = d.DataPoints[0].Value
+			}
+		}
+	}
+	assert.Equal(t, map[string]int64{
+		"test.counter": 0,
+		"test.updown":  0,
+	}, got)
+}

--- a/x-pack/apm-server/sampling/groups.go
+++ b/x-pack/apm-server/sampling/groups.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-server/internal/otelmetric"
 )
 
 const minReservoirSize = 1000
@@ -72,7 +73,7 @@ func newTraceGroups(
 	maxDynamicServiceGroups int,
 	ingestRateDecayFactor float64,
 ) *traceGroups {
-	numDynamicServiceGroupsCounter, _ := meter.Int64UpDownCounter("apm-server.sampling.tail.dynamic_service_groups")
+	numDynamicServiceGroupsCounter := otelmetric.NewInt64UpDownCounter(meter, "apm-server.sampling.tail.dynamic_service_groups")
 	groups := &traceGroups{
 		ingestRateDecayFactor:          ingestRateDecayFactor,
 		maxDynamicServiceGroups:        maxDynamicServiceGroups,

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/apm-data/model/modelpb"
 
 	"github.com/elastic/apm-server/internal/logs"
+	"github.com/elastic/apm-server/internal/otelmetric"
 	"github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage"
 	"github.com/elastic/apm-server/x-pack/apm-server/sampling/pubsub"
 )
@@ -94,12 +95,12 @@ func NewProcessor(params ProcessorParams) (*Processor, error) {
 		stopped:           make(chan struct{}),
 	}
 
-	p.eventMetrics.processed, _ = meter.Int64Counter("apm-server.sampling.tail.events.processed")
-	p.eventMetrics.dropped, _ = meter.Int64Counter("apm-server.sampling.tail.events.dropped")
-	p.eventMetrics.stored, _ = meter.Int64Counter("apm-server.sampling.tail.events.stored")
-	p.eventMetrics.sampled, _ = meter.Int64Counter("apm-server.sampling.tail.events.sampled")
-	p.eventMetrics.headUnsampled, _ = meter.Int64Counter("apm-server.sampling.tail.events.head_unsampled")
-	p.eventMetrics.failedWrites, _ = meter.Int64Counter("apm-server.sampling.tail.events.failed_writes")
+	p.eventMetrics.processed = otelmetric.NewInt64Counter(meter, "apm-server.sampling.tail.events.processed")
+	p.eventMetrics.dropped = otelmetric.NewInt64Counter(meter, "apm-server.sampling.tail.events.dropped")
+	p.eventMetrics.stored = otelmetric.NewInt64Counter(meter, "apm-server.sampling.tail.events.stored")
+	p.eventMetrics.sampled = otelmetric.NewInt64Counter(meter, "apm-server.sampling.tail.events.sampled")
+	p.eventMetrics.headUnsampled = otelmetric.NewInt64Counter(meter, "apm-server.sampling.tail.events.head_unsampled")
+	p.eventMetrics.failedWrites = otelmetric.NewInt64Counter(meter, "apm-server.sampling.tail.events.failed_writes")
 
 	return p, nil
 }


### PR DESCRIPTION
## Motivation/summary

apm-server's monitoring tree (the `/stats` HTTP endpoint and the libbeat monitoring snapshot) is the source we use to generate three sets of upstream field mappings:

- the metricbeat `beat` module's [`_meta/fields.yml`](https://github.com/elastic/beats/blob/main/metricbeat/module/beat/_meta/fields.yml) and [`stats/_meta/fields.yml`](https://github.com/elastic/beats/blob/main/metricbeat/module/beat/stats/_meta/fields.yml)
- the Elasticsearch stack-monitoring templates [`monitoring-beats.json`](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json) and [`monitoring-beats-mb.json`](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json)
- the elastic_agent integration package's [`beat-stats-fields.yml`](https://github.com/elastic/integrations/blob/main/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml)

Mappings can include fields that aren't always emitted at runtime — the problem is the tooling we use to derive those mappings. The stats-to-mapping helper from the closed [#13638](https://github.com/elastic/apm-server/pull/13638) (and any equivalent script) reads a single `/stats` snapshot and infers field types from what's there. If a counter only appears in `/stats` after some specific code path has fired, it's not in the snapshot and silently gets dropped from the regenerated mappings.

After [#15094](https://github.com/elastic/apm-server/pull/15094) "Translate otel metrics to libbeat monitoring", that's exactly what happens: the OpenTelemetry instruments backing the new monitoring path are lazy. An `Int64Counter` only contributes a data point — and therefore only appears in `/stats` — once `.Add()` has been called on it. Counters whose code path hasn't fired yet (most error responses, OTLP variants we haven't seen traffic for, agent-config cache hits/misses, etc.) are absent from the snapshot. Pre-#15094, libbeat monitoring counters were registered up front and emitted as `0` by default, which gave `/stats` an exhaustive enumeration of every counter the server defines.

This PR restores that property under the OpenTelemetry path so the mapping-generation tooling can regenerate field mappings from a single `/stats` capture without needing to drive every error path.

## What this changes

### Eager zero-init helper

Adds a small `internal/otelmetric` package whose constructors (`NewInt64Counter`, `NewInt64UpDownCounter`) call `.Add(0)` at instrument creation, ensuring each instrument has at least one data point so the SDK exports it. Gauges and histograms are intentionally not in the helper: a synthetic `Record(0)` would falsely declare a gauge's current value as 0 and would inflate a histogram's observation count.

### Per-package eager registration

Each registration site that defines `apm-server.*` metrics is converted to use the helpers:

- `internal/agentcfg/elasticsearch.go` (6 counters under `apm-server.agentcfg.elasticsearch.*` plus the cache-entries gauge converted to an `Int64UpDownCounter` with delta tracking, since the cumulative sum of its deltas equals the current cache size)
- `internal/beater/api/intake/handler.go` (3 counters under `apm-server.processor.stream.*`)
- `internal/beater/beater.go` (`apm-server.sampling.transactions_dropped`)
- `internal/model/modelprocessor/eventcounter.go` (`apm-server.processor.<event-type>.transformations`)
- `x-pack/apm-server/sampling/processor.go` (6 counters under `apm-server.sampling.tail.events.*`)
- `x-pack/apm-server/sampling/groups.go` (`apm-server.sampling.tail.dynamic_service_groups`)

### HTTP middleware and gRPC interceptor

`MonitoringMiddleware` and `metricsInterceptor` produce counter names that depend on a `request.ResultID` chosen per-request. A new `request.AllResultIDs` slice is iterated at construction so every `(prefix, ResultID)` pair has its counter created up front. This is the largest single contributor — it covers `apm-server.acm.*`, `apm-server.root.*`, `apm-server.server.*`, `apm-server.otlp.{grpc,http}.*` error counters that previously only appeared after a matching error response.

The interceptor's and middleware's per-request counter storage was previously a `sync.Map` (added in #16182 to fix a concurrent-map race). Since every `(prefix, ResultID)` pair is now created in advance, the maps are never written after construction and `sync.Map`'s concurrent-mutation guarantees aren't needed. Both refactor to a plain map populated at startup and read-only at request time. The map keys avoid the per-call `prefix + string(id)` string concat (interceptor uses a `{prefix, ResultID}` struct key; middleware uses two `map[ResultID]Counter` since the prefix is fixed per-instance), so the hot path becomes allocation-free. A missing entry now logs `"BUG: monitoring counter missing from eager registration"` instead of silently creating a counter on first use — drift becomes runtime-loud.

The OTLP gRPC dispatch (three method names → three legacy prefixes) is consolidated into a single `otlpGRPCLegacyMetricsPrefixes` map keyed by gRPC method. The same map drives both per-call dispatch in `Interceptor()` and the eager-registration loop in `Metrics()`; adding a new OTLP signal is one map entry.

### Single source of truth for the canonical ResultID set

`internal/beater/request/result.go` previously declared the same set of ResultIDs in three places: a const block, the `MapResultIDToStatus` map, and a `ResultID`-slice literal in `AllResultIDs`. A new ID could land in the const block and any inc() call site without ever being added to `AllResultIDs`, silently breaking the eager-registration property.

The file now has a single `resultIDStatus` map keyed by ResultID; `init()` derives both `AllResultIDs` and `MapResultIDToStatus` from it. Adding a ResultID is one new entry; forgetting the entry surfaces immediately because the new ID isn't in `AllResultIDs`, the eager loop skips it, and the first inc() logs the BUG line which the strict tests fail on.

Two dead constants (`IDEventReceivedCount`, `IDEventDroppedCount` — leftovers from the Jaeger removal in #14791) are removed in the same change since they had no remaining callers.

### Float64 translator gap (fixes #20996)

`apm-server.sampling.tail.storage.disk_usage_threshold_pct` is a `Float64Gauge` introduced in #20464 (present in 9.2.0+) and has **never** appeared in `/stats`, even with TBS enabled and the storage manager actively recording values. `addAPMServerMetricsToMap` in `internal/beatcmd/beat.go` only handled `Sum[int64]` / `Gauge[int64]`; float64 instruments fell through the `else`. The translator is extended with a `getScalarFloat64` path so float-typed `apm-server.*` instruments are reported via `monitoring.ReportFloat`. The validation rule for "single dimensionless data point" is hoisted into a generic helper `scalarValue[T int64 | float64]` shared by both getters. `TestMonitoringApmServer` is extended with a `Float64Gauge` to lock the float branch in.

### `unsupported_dropped` guard removal

`apm-server.otlp.{grpc,http}.metrics.consumer.unsupported_dropped` was guarded by `if stats.UnsupportedMetricsDropped > 0` inside the observable-counter callback, so it never appeared until at least one unsupported metric was dropped. The guard is removed; the callback now always observes the (possibly zero) counter.

### libbeat.output / libbeat.pipeline lazy emission

The docappender → libbeat translation in `addDocappenderLibbeatOutputMetrics` and `addDocappenderLibbeatPipelineMetrics` (`internal/beatcmd/beat.go`) used to report each `libbeat.output.events.*` / `libbeat.output.write.bytes` / `libbeat.pipeline.events.total` field only inside the matching metric-name switch arm. Before docappender's first publish — i.e., at process start with ES output configured — none of the source metric names had data points, so eight fields were missing from `/stats`:

```
libbeat.output.events.{acked,active,batches,failed,toomany,total}
libbeat.output.write.bytes
libbeat.pipeline.events.total
```

Two earlier attempts to address this were rejected: an always-emit-zero adapter (10a8d1a4, reverted in 702bc903) fabricated zeros even when docappender stopped reporting an instrument, masking renames; an upstream `Add(0)` PR in [`elastic/go-docappender#317`](https://github.com/elastic/go-docappender/pull/317) (now closed) put the eager init at the right architectural layer but couldn't seed the three status-attributed fields without changing docappender's test contract for `events.processed`.

This PR converts the two `NewFunc` callbacks to use per-instance persistent state structs (`libbeatOutputState`, `libbeatPipelineState`) backed by `atomic.Bool` / `atomic.Int64` fields. The structs zero-initialise at process start, so every field surfaces in `/stats` from the first scrape, before any indexing has occurred. Each scrape updates only the fields docappender currently exports and reports the full set; a rename or drop of an upstream instrument leaves the field at its last-known value rather than snapping back to a fabricated zero. The `if writeBytes > 0` guard is removed in the same change, since `writeBytes` is now a struct field rather than a per-call local. `"type": "elasticsearch"` and the field emission are gated on having ever observed the docappender scope, so console-output runs keep an empty `libbeat.output` sub-tree as before.

Drift in docappender's instrument names is caught by `TestLibbeatMetrics`, which exercises real traffic and asserts specific cumulative values for every field — a rename fails that test loudly. `TestLibbeatMetricsEagerZero` locks the eager-zero contract directly: build a Beat with `output.elasticsearch`, create a docappender with no traffic, assert every field appears at zero in the snapshot.

### Walker performance

`addAPMServerMetricsToMap` walks each metric's dotted path. The original `strings.Split` allocated a `[]string` per call; replaced with `strings.SplitAfterSeq` which yields each segment with its trailing `.` preserved, and `strings.CutSuffix(seg, ".")` distinguishes intermediate (descend) from leaf (assign) without lookahead state. Benchstat over a 3-metric input:

```
                            │ split        │ splitafterseq                  │
                            │ sec/op       │ sec/op     vs base             │
AddAPMServerMetricsToMap-16   1.175µ ± 1%   1.078µ ± 2%  -8.22% (p=0.000)
                              2.492Ki ± 0%  2.305Ki ± 0% -7.52% (p=0.000) [B/op]
                              18.00 ± 0%    15.00 ± 0% -16.67% (p=0.000) [allocs]
```

### Interceptor and middleware performance

The sync.Map → plain map swap, combined with the struct/ID-keyed lookup, takes both hot paths to zero allocations:

```
                            │ syncmap       │ plain map                          │
                            │ sec/op        │ sec/op       vs base               │
Interceptor-16                738.1n ± 0%    405.2n ± 2%   -45.11% (p=0.000)
                              304.0 ± 0%     0.0 ± 0%     -100.00% (p=0.000) [B/op]
                              9.000 ± 0%     0.000 ± 0%   -100.00% (p=0.000) [allocs]

MonitoringMiddleware-16       906.6n ± 2%    432.2n ± 1%   -52.32% (p=0.000)
                              320.0 ± 0%     0.0 ± 0%     -100.00% (p=0.000) [B/op]
                              11.00 ± 0%     0.00 ± 0%    -100.00% (p=0.000) [allocs]
```

### Tests

Strict-match assertions stay strict. `monitoringtest/opentelemetry.go` is byte-identical to `main`. `TestMonitoringHandler` (middleware) and `TestMetrics` (interceptor) build the full expected map in-place — `prefix × request.AllResultIDs → int64(0)` plus the per-test non-zero overrides — before calling the existing `ExpectOtelMetrics`. Tests with an unbounded eager-init footprint (mux api tests, otlp http/grpc tests, eventcounter test) stay on `ExpectContainOtelMetrics` (subset semantics), which is what they used before #15094.

`TestMonitoringApmServer` extended with a `Float64Gauge` so the `getScalarFloat64` path is verified.

Two benchmarks added so future regressions are caught:

- `BenchmarkAddAPMServerMetricsToMap` in `internal/beatcmd/beat_test.go`.
- `BenchmarkInterceptor` in `internal/beater/interceptors/metrics_test.go`.
- `BenchmarkMonitoringMiddleware` in `internal/beater/middleware/monitoring_middleware_test.go`.

## How to test these changes

```shell
# Build and run with no traffic.
go build -o /tmp/apm-server ./x-pack/apm-server
/tmp/apm-server -e -c apm-server.yml &
sleep 4
curl -s http://127.0.0.1:5066/stats | jq '."apm-server"'
```

Before this change, `apm-server.*` shows only metrics that have actually been incremented (typically just the few `sampling.tail.storage.*` int64 gauges if TBS is enabled, plus whatever traffic has triggered). After this change, the full enumerated set (`acm`, `agentcfg`, `otlp`, `processor`, `root`, `sampling`, `server`) is present at zero — and `disk_usage_threshold_pct` shows up under `sampling.tail.storage` for the first time.

Unit tests:

```shell
go test -race ./internal/... ./x-pack/...
```

## Related issues

Unblocks the mapping-regeneration tooling in [#13638](https://github.com/elastic/apm-server/pull/13638) and the periodic upstream-mapping-sync work in [#15533](https://github.com/elastic/apm-server/issues/15533) and [#13475](https://github.com/elastic/apm-server/issues/13475).

Part of #20991.
Fixes #20996 as a side effect (float64 translator gap).


