### PR TITLE
iserver-test: Fix 9.4.0-SNAPSHOT upgrade test failures

### DIFF
--- a/integrationservertest/internal/elasticsearch/client.go
+++ b/integrationservertest/internal/elasticsearch/client.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v8"
@@ -156,13 +157,17 @@ func (c *Client) APMDSDocCount(ctx context.Context) (DataStreamsDocCount, error)
 	qry := c.es.Esql.Query().Query(q)
 	resp, err := query.Helper[docCount](ctx, qry)
 	if err != nil {
+		// Suppress these errors as it only indicates no data is available yet.
+		ignoreErrReasons := []string{
+			`Found 1 problem
+line 1:1: Unknown index [traces-apm*,apm-*,traces-*.otel-*,logs-apm*,apm-*,logs-*.otel-*,metrics-apm*,apm-*,metrics-*.otel-*]`,
+			`Found 1 problem
+line 2:9: Unknown column [data_stream.type]`,
+		}
 		var eserr *types.ElasticsearchError
-		// suppress this error as it only indicates no data is available yet.
-		expected := `Found 1 problem
-line 1:1: Unknown index [traces-apm*,apm-*,traces-*.otel-*,logs-apm*,apm-*,logs-*.otel-*,metrics-apm*,apm-*,metrics-*.otel-*]`
 		if errors.As(err, &eserr) &&
 			eserr.ErrorCause.Reason != nil &&
-			*eserr.ErrorCause.Reason == expected {
+			slices.Contains(ignoreErrReasons, *eserr.ErrorCause.Reason) {
 			return DataStreamsDocCount{}, nil
 		}
 

--- a/integrationservertest/internal/gen/generator.go
+++ b/integrationservertest/internal/gen/generator.go
@@ -19,7 +19,6 @@ package gen
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,7 +61,7 @@ func New(url, apikey string, kbc *kibana.Client, logger *zap.Logger) *Generator 
 // This may lead to data loss if the final flush takes more than 30s, which may happen if the
 // quantity of data ingested with runBlocking gets too big. The current quantity does not
 // trigger this behavior.
-func (g *Generator) RunBlockingWait(ctx context.Context, version ech.Version, integrations bool) error {
+func (g *Generator) RunBlockingWait(ctx context.Context, version ech.Version) error {
 	g.logger.Info("wait for apm server to be ready")
 	if err := g.waitForAPMToBePublishReady(ctx); err != nil {
 		return fmt.Errorf("failed to wait for apm server: %w", err)
@@ -71,13 +70,6 @@ func (g *Generator) RunBlockingWait(ctx context.Context, version ech.Version, in
 	g.logger.Info("ingest data")
 	if err := g.retryRunBlocking(ctx, version, 2); err != nil {
 		return fmt.Errorf("cannot run generator: %w", err)
-	}
-
-	if integrations {
-		g.logger.Info("re-apply apm policy")
-		if err := g.reapplyAPMPolicy(ctx, version); err != nil {
-			return fmt.Errorf("failed to re-apply apm policy: %w", err)
-		}
 	}
 
 	// Simply wait for some arbitrary time, for the data to be flushed.
@@ -166,20 +158,6 @@ func (g *Generator) retryRunBlocking(ctx context.Context, version ech.Version, r
 	}
 
 	return finalErr
-}
-
-func (g *Generator) reapplyAPMPolicy(ctx context.Context, version ech.Version) error {
-	policyID := "elastic-cloud-apm"
-	description := fmt.Sprintf("%s %s", version, rand.Text()[:10])
-
-	if err := g.kbc.UpdatePackagePolicyDescriptionByID(ctx, policyID, version, description); err != nil {
-		return fmt.Errorf(
-			"cannot update %s package policy description: %w",
-			policyID, err,
-		)
-	}
-
-	return nil
 }
 
 type apmInfoResp struct {

--- a/integrationservertest/steps.go
+++ b/integrationservertest/steps.go
@@ -188,7 +188,7 @@ func (i ingestStep) Step(t *testing.T, ctx context.Context, e *testStepEnv) {
 	beforeIngestDSDocCount := getDocCountPerDS(t, ctx, e.esc, ignoreDS...)
 
 	t.Logf("------ ingest in %s------", e.currentVersion())
-	err := e.gen.RunBlockingWait(ctx, e.currentVersion(), e.integrations)
+	err := e.gen.RunBlockingWait(ctx, e.currentVersion())
 	// Check if there are any panic logs in elastic-agent so we can report it.
 	t.Log("checking for panic logs")
 	checkPanicLogs(t, ctx, e.esc)
@@ -346,7 +346,7 @@ func (i ingestV7Step) Step(t *testing.T, ctx context.Context, e *testStepEnv) {
 	}
 
 	t.Logf("------ ingest in %s ------", e.currentVersion())
-	err := e.gen.RunBlockingWait(ctx, e.currentVersion(), e.integrations)
+	err := e.gen.RunBlockingWait(ctx, e.currentVersion())
 	require.NoError(t, err)
 
 	t.Logf("------ ingest check in %s ------", e.currentVersion())


### PR DESCRIPTION
Closes https://github.com/elastic/apm-server/issues/20994.

Removed APM package policy rename, which does not work for >= 9.4.0. Also suppressed ES error when data does not exist.