### PR TITLE
ci: weekly drift check between /stats and upstream mapping files

### DIFF
--- a/.github/workflows/monitoring-metric-mapping-drift.yml
+++ b/.github/workflows/monitoring-metric-mapping-drift.yml
@@ -1,0 +1,243 @@
+---
+name: monitoring-metric-mapping-drift
+
+# Weekly cron that detects drift between apm-server's /stats endpoint and the
+# upstream mapping files in elastic/elasticsearch, elastic/beats, and
+# elastic/integrations. When drift is detected and no open drift issue exists,
+# a new issue is opened with the per-file change summary, a reproduction
+# recipe, and a link to the workflow run (where the full diff is attached as
+# an artifact).
+#
+# Background: elastic/apm-server#21000.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: '0 6 * * MON'
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    env:
+      DRIFT_LABEL: monitoring-metrics-drift
+      WORK: ${{ github.workspace }}/.drift
+      UPSTREAM_FILES: |
+        elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
+        elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
+        beats/metricbeat/module/beat/_meta/fields.yml
+        beats/metricbeat/module/beat/stats/_meta/fields.yml
+        integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml
+    steps:
+      - name: Checkout apm-server
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build apm-server from main
+        run: go build -o "$WORK/apm-server" ./x-pack/apm-server
+
+      - name: Install stats-to-mapping
+        run: go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
+
+      - name: Run apm-server, capture /stats
+        run: |
+          set -euo pipefail
+          mkdir -p "$WORK/data"
+          install -m 0600 /dev/stdin "$WORK/apm-server.yml" <<'EOF'
+          apm-server:
+            host: "127.0.0.1:18200"
+            sampling.tail:
+              enabled: true
+              interval: 1m
+              policies:
+                - sample_rate: 1
+          output.elasticsearch:
+            hosts: ["http://127.0.0.1:9200"]
+          path.data: ${WORK}/data
+          http.enabled: true
+          http.host: "127.0.0.1"
+          http.port: 15066
+          logging.level: warning
+          EOF
+          # Substitute $WORK because the heredoc was quoted.
+          sed -i "s|\${WORK}|$WORK|" "$WORK/apm-server.yml"
+          "$WORK/apm-server" --strict.perms=false -e -c "$WORK/apm-server.yml" >"$WORK/apm-server.log" 2>&1 &
+          echo $! > "$WORK/apm-server.pid"
+          for attempt in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:15066/stats -o "$WORK/stats.json"; then
+              echo "Captured /stats on attempt $attempt"
+              break
+            fi
+            sleep 1
+          done
+          kill "$(cat "$WORK/apm-server.pid")" || true
+          wait || true
+          test -s "$WORK/stats.json"
+          # Sanity: TBS-enabled stats should contain sampling.tail.storage.
+          jq -e '.["apm-server"].sampling.tail.storage' "$WORK/stats.json" >/dev/null
+
+      - name: Sparse-checkout upstream mapping files
+        run: |
+          set -euo pipefail
+          mkdir -p "$WORK/upstream"
+          clone() {
+            local repo=$1 path=$2
+            git clone --depth 1 --filter=blob:none --no-checkout \
+              "https://github.com/elastic/$repo" "$WORK/upstream/$repo"
+            git -C "$WORK/upstream/$repo" sparse-checkout init --no-cone
+            git -C "$WORK/upstream/$repo" sparse-checkout set "$path"
+            git -C "$WORK/upstream/$repo" checkout
+          }
+          clone elasticsearch  x-pack/plugin/core/template-resources/src/main/resources
+          clone beats          metricbeat/module/beat
+          clone integrations   packages/elastic_agent/data_stream/apm_server_metrics
+
+      - name: Run stats-to-mapping
+        run: |
+          set -euo pipefail
+          stats-to-mapping \
+            "$WORK/upstream/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json" \
+            "$WORK/upstream/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json" \
+            "$WORK/upstream/beats/metricbeat/module/beat/_meta/fields.yml" \
+            "$WORK/upstream/beats/metricbeat/module/beat/stats/_meta/fields.yml" \
+            "$WORK/upstream/integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml" \
+            < "$WORK/stats.json"
+
+      - name: Compute drift per file
+        id: drift
+        run: |
+          set -euo pipefail
+          : > "$WORK/drift.diff"
+          : > "$WORK/drift.summary.md"
+          drift_found=false
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            repo=${path%%/*}
+            file=${path#*/}
+            cd "$WORK/upstream/$repo"
+            if git diff --quiet -- "$file"; then
+              cd - >/dev/null
+              continue
+            fi
+            drift_found=true
+            added=$(git diff --numstat -- "$file" | awk '{print $1}')
+            removed=$(git diff --numstat -- "$file" | awk '{print $2}')
+            printf -- '- `%s/%s` — +%s / -%s\n' "$repo" "$file" "$added" "$removed" >> "$WORK/drift.summary.md"
+            {
+              printf '\n## %s/%s\n\n```diff\n' "$repo" "$file"
+              git diff -- "$file"
+              printf '\n```\n'
+            } >> "$WORK/drift.diff"
+            cd - >/dev/null
+          done <<< "$UPSTREAM_FILES"
+          echo "drift=$drift_found" >> "$GITHUB_OUTPUT"
+
+      - name: Upload drift diff artifact
+        if: steps.drift.outputs.drift == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-diff
+          path: |
+            ${{ env.WORK }}/drift.diff
+            ${{ env.WORK }}/stats.json
+          retention-days: 30
+
+      - name: Open drift issue if none exists
+        if: steps.drift.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --repo "$REPO" --label "$DRIFT_LABEL" --state open --json number --jq 'length')
+          if [ "$existing" -gt 0 ]; then
+            echo "Open drift issue already exists; not opening another"
+            exit 0
+          fi
+          today=$(date -u +%Y-%m-%d)
+          BODY=$WORK/issue-body.md
+          {
+            cat <<HEADER
+          The weekly drift-check workflow detected divergence between apm-server's \`/stats\` endpoint and the upstream mapping files maintained in \`elastic/elasticsearch\`, \`elastic/beats\`, and \`elastic/integrations\`.
+
+          Detected on $today by [workflow run]($RUN_URL). The full \`git diff\` of every drifted file is attached to that run as the \`drift-diff\` artifact, alongside the captured \`stats.json\`.
+
+          ## Files that drifted
+
+          HEADER
+            cat "$WORK/drift.summary.md"
+            cat <<RECIPE
+
+          ## Reproduce locally
+
+          \`\`\`shell
+          # 1. Install the regen tool.
+          go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
+
+          # 2. Build apm-server from main and capture a TBS-enabled /stats snapshot.
+          go build -o /tmp/apm-server ./x-pack/apm-server
+          install -m 0600 /dev/stdin /tmp/apm-server.yml <<'CFG'
+          apm-server:
+            host: "127.0.0.1:18200"
+            sampling.tail:
+              enabled: true
+              interval: 1m
+              policies:
+                - sample_rate: 1
+          output.elasticsearch:
+            hosts: ["http://127.0.0.1:9200"]
+          path.data: /tmp/apm-server-data
+          http.enabled: true
+          http.host: "127.0.0.1"
+          http.port: 15066
+          logging.level: warning
+          CFG
+          /tmp/apm-server --strict.perms=false -e -c /tmp/apm-server.yml &
+          sleep 6
+          curl -s http://127.0.0.1:15066/stats > /tmp/stats.json
+          kill %1; wait || true
+
+          # 3. Clone the three upstream repos (sparse).
+          for r in elasticsearch beats integrations; do
+            git clone --depth 1 --filter=blob:none "https://github.com/elastic/\$r" "/tmp/\$r"
+          done
+
+          # 4. Run the regen.
+          stats-to-mapping \\
+            /tmp/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json \\
+            /tmp/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json \\
+            /tmp/beats/metricbeat/module/beat/_meta/fields.yml \\
+            /tmp/beats/metricbeat/module/beat/stats/_meta/fields.yml \\
+            /tmp/integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml \\
+            < /tmp/stats.json
+
+          # 5. Inspect the diffs and prepare upstream PRs.
+          for r in elasticsearch beats integrations; do
+            echo "=== \$r ==="; git -C "/tmp/\$r" diff
+          done
+          \`\`\`
+
+          ## Resolution
+
+          Open a PR in each upstream repo with the diffs above, then close this issue.
+
+          Tracked by #21000. This workflow will not open another issue while this one stays open.
+          RECIPE
+          } > "$BODY"
+          gh issue create --repo "$REPO" \
+            --title "Monitoring metric mappings drifted from /stats ($today)" \
+            --label bug \
+            --label "$DRIFT_LABEL" \
+            --body-file "$BODY"

--- a/.github/workflows/stats-to-mapping-drift.yml
+++ b/.github/workflows/stats-to-mapping-drift.yml
@@ -3,10 +3,11 @@ name: stats-to-mapping-drift
 
 # Weekly cron that detects drift between apm-server's /stats endpoint and the
 # upstream mapping files in elastic/elasticsearch, elastic/beats, and
-# elastic/integrations. When drift is detected and no open drift issue exists,
-# a new issue is opened with the per-file change summary, a reproduction
-# recipe, and a link to the workflow run (where the full diff is attached as
-# an artifact).
+# elastic/integrations. The orchestration lives in
+# script/stats-to-mapping-drift.sh (also runnable as `make
+# stats-to-mapping-drift`); this workflow wraps the script with
+# GitHub-Actions-specific concerns: artifact upload and drift-issue
+# creation.
 #
 # Background: elastic/apm-server#21000.
 
@@ -29,18 +30,6 @@ jobs:
     env:
       DRIFT_LABEL: stats-to-mapping-drift
       WORK: ${{ github.workspace }}/.drift
-      STATS_PORT: 15066
-      # Single source of truth for the files this job tracks. Each line is
-      # "<repo>/<path-within-repo>". The first slash-separated segment is
-      # treated as the github.com/elastic/<repo> name; the remainder is the
-      # file's path inside that repo. Sparse-checkout, the regen invocation,
-      # the drift loop, and the issue-body recipe all derive from this.
-      UPSTREAM_FILES: |
-        elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
-        elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
-        beats/metricbeat/module/beat/_meta/fields.yml
-        beats/metricbeat/module/beat/stats/_meta/fields.yml
-        integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml
     steps:
       - name: Checkout apm-server
         uses: actions/checkout@v6
@@ -50,133 +39,53 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build apm-server from main
-        run: go build -o "$WORK/apm-server" ./x-pack/apm-server
-
-      - name: Install stats-to-mapping
-        run: go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
-
-      # Write the apm-server config to a file. The same file is read back later
-      # to embed in the drift issue's reproduction recipe (with path.data
-      # rewritten), so the two can never drift.
-      - name: Write apm-server config
-        run: |
-          set -euo pipefail
-          mkdir -p "$WORK/data"
-          install -m 0600 /dev/stdin "$WORK/apm-server.yml" <<EOF
-          apm-server:
-            host: "127.0.0.1:18200"
-            sampling.tail:
-              enabled: true
-              interval: 1m
-              policies:
-                - sample_rate: 1
-          output.elasticsearch:
-            hosts: ["http://127.0.0.1:9200"]
-          path.data: $WORK/data
-          http.enabled: true
-          http.host: "127.0.0.1"
-          http.port: $STATS_PORT
-          logging.level: warning
-          EOF
-
-      - name: Run apm-server, capture /stats
-        run: |
-          set -euo pipefail
-          "$WORK/apm-server" --strict.perms=false -e -c "$WORK/apm-server.yml" \
-            >"$WORK/apm-server.log" 2>&1 &
-          pid=$!
-          trap 'kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null || true' EXIT
-          for attempt in $(seq 1 30); do
-            if curl -sf "http://127.0.0.1:$STATS_PORT/stats" -o "$WORK/stats.json"; then
-              echo "Captured /stats on attempt $attempt"
-              break
-            fi
-            sleep 1
-          done
-          test -s "$WORK/stats.json"
-          # TBS-enabled stats must include sampling.tail.storage.* — fail fast
-          # if the config or apm-server's stats shape changed.
-          jq -e '.["apm-server"].sampling.tail.storage' "$WORK/stats.json" >/dev/null
-
-      - name: Sparse-checkout upstream mapping files
-        run: |
-          set -euo pipefail
-          mkdir -p "$WORK/upstream"
-          declare -A repo_paths
-          while IFS= read -r path; do
-            [ -z "$path" ] && continue
-            repo=${path%%/*}
-            repo_paths[$repo]+="${path#*/} "
-          done <<< "$UPSTREAM_FILES"
-          for repo in "${!repo_paths[@]}"; do
-            git clone --depth 1 --filter=blob:none --no-checkout \
-              "https://github.com/elastic/$repo" "$WORK/upstream/$repo"
-            git -C "$WORK/upstream/$repo" sparse-checkout init --no-cone
-            # shellcheck disable=SC2086
-            git -C "$WORK/upstream/$repo" sparse-checkout set ${repo_paths[$repo]}
-            git -C "$WORK/upstream/$repo" checkout
-          done
-
-      - name: Run stats-to-mapping
-        run: |
-          set -euo pipefail
-          mapfile -t paths < <(printf '%s\n' "$UPSTREAM_FILES" \
-            | awk -v w="$WORK" 'NF > 0 { print w "/upstream/" $0 }')
-          stats-to-mapping "${paths[@]}" < "$WORK/stats.json"
-
-      - name: Compute drift per file
+      # Continues on drift so the artifact upload and issue-creation steps
+      # below can run. The script exits 1 only when drift is detected;
+      # genuine errors (build failure, /stats unreachable) surface as the
+      # script aborting before producing a drift.diff.
+      - name: Run drift check
         id: drift
+        continue-on-error: true
+        run: make stats-to-mapping-drift
+
+      # If drift.diff exists and is non-empty, the script detected drift.
+      # If it doesn't exist, an earlier step in the script failed and the
+      # workflow should fail too.
+      - name: Classify outcome
+        id: classify
         run: |
           set -euo pipefail
-          : > "$WORK/drift.diff"
-          : > "$WORK/drift.summary.md"
-          drifted_files=0
-          while IFS= read -r path; do
-            [ -z "$path" ] && continue
-            repo=${path%%/*}
-            file=${path#*/}
-            tree="$WORK/upstream/$repo"
-            if git -C "$tree" diff --quiet -- "$file"; then
-              continue
-            fi
-            drifted_files=$((drifted_files + 1))
-            read -r added removed _ < <(git -C "$tree" diff --numstat -- "$file")
-            printf -- '- `%s/%s` — +%s / -%s\n' "$repo" "$file" "$added" "$removed" \
-              >> "$WORK/drift.summary.md"
-            {
-              printf '\n## %s/%s\n\n```diff\n' "$repo" "$file"
-              git -C "$tree" diff -- "$file"
-              printf '\n```\n'
-            } >> "$WORK/drift.diff"
-          done <<< "$UPSTREAM_FILES"
-          echo "drifted_files=$drifted_files" >> "$GITHUB_OUTPUT"
+          if [ ! -f "$WORK/drift.diff" ]; then
+            echo "Drift script aborted before producing a diff; failing the job"
+            exit 1
+          fi
+          if [ -s "$WORK/drift.diff" ]; then
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Upload drift diff artifact
-        if: steps.drift.outputs.drifted_files != '0'
+      - name: Upload drift artifact
+        if: steps.classify.outputs.drifted == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: drift-diff
           path: |
             ${{ env.WORK }}/drift.diff
+            ${{ env.WORK }}/drift.summary.md
             ${{ env.WORK }}/stats.json
           retention-days: 30
 
-      # If drift is detected and no open drift issue already exists, file a new
-      # issue. The issue body has three sections: a one-line summary, a list of
-      # drifted files, and a copy-pasteable local reproduction recipe.
-      #
-      # The apm-server config in the recipe is read back from the file written
-      # earlier in this job (with the CI-specific path.data rewritten) so the
-      # recipe and the CI run can never disagree about what config produced
-      # the captured /stats.
+      # File a single tracking issue with the per-file change summary, the
+      # workflow-run URL, and a copy-pasteable local reproduction recipe.
+      # Skipped if any open issue already carries the drift label, so a
+      # sustained drift event produces one issue, not a weekly stream.
       - name: Open drift issue if none exists
-        if: steps.drift.outputs.drifted_files != '0'
+        if: steps.classify.outputs.drifted == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          DRIFTED_FILES: ${{ steps.drift.outputs.drifted_files }}
         run: |
           set -euo pipefail
           existing=$(gh issue list --repo "$REPO" --label "$DRIFT_LABEL" \
@@ -187,20 +96,13 @@ jobs:
           fi
 
           today=$(date -u +%Y-%m-%d)
-
-          # Build the path block for the recipe by prefixing each tracked file
-          # with /tmp/. Trailing backslashes continue the shell command.
-          recipe_paths=$(printf '%s\n' "$UPSTREAM_FILES" \
-            | awk 'NF > 0 { print "      /tmp/" $0 " \\" }')
-
-          # Reuse the exact apm-server config from the CI run, with path.data
-          # rewritten to the local /tmp location used in the recipe.
-          recipe_config=$(sed "s|$WORK/data|/tmp/apm-server-data|" "$WORK/apm-server.yml")
+          # The script's drift.summary.md is the per-file bullet list.
+          drifted_files=$(wc -l < "$WORK/drift.summary.md" | tr -d ' ')
 
           BODY=$WORK/issue-body.md
           {
             cat <<HEADER
-          The weekly drift-check workflow detected drift in **$DRIFTED_FILES file(s)** between apm-server's \`/stats\` endpoint and the upstream mapping files in \`elastic/elasticsearch\`, \`elastic/beats\`, and \`elastic/integrations\`.
+          The weekly drift-check workflow detected drift in **$drifted_files file(s)** between apm-server's \`/stats\` endpoint and the upstream mapping files in \`elastic/elasticsearch\`, \`elastic/beats\`, and \`elastic/integrations\`.
 
           Detected on $today by [workflow run]($RUN_URL). The full \`git diff\` of every drifted file is attached to that run as the \`drift-diff\` artifact, alongside the captured \`stats.json\`.
 
@@ -208,44 +110,23 @@ jobs:
 
           HEADER
             cat "$WORK/drift.summary.md"
-            cat <<RECIPE
+            cat <<'RECIPE'
 
           ## Reproduce locally
 
           From an apm-server checkout:
 
-          \`\`\`shell
-          # 1. Install the regen tool. Make sure \$(go env GOPATH)/bin is on PATH.
-          go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
-          export PATH="\$PATH:\$(go env GOPATH)/bin"
+          ```shell
+          make stats-to-mapping-drift
+          ```
 
-          # 2. Build apm-server and capture a TBS-enabled /stats snapshot.
-          go build -o /tmp/apm-server ./x-pack/apm-server
-          install -m 0600 /dev/stdin /tmp/apm-server.yml <<'CFG'
-          $recipe_config
-          CFG
-          /tmp/apm-server --strict.perms=false -e -c /tmp/apm-server.yml &
-          pid=\$!
-          sleep 6
-          curl -s http://127.0.0.1:$STATS_PORT/stats > /tmp/stats.json
-          kill "\$pid"; wait "\$pid" 2>/dev/null || true
+          The Makefile target wraps `script/stats-to-mapping-drift.sh`. It builds apm-server, captures `/stats` with TBS enabled, sparse-clones the three upstream repos under `.drift/upstream/`, runs the regen tool, and prints the per-file diff. Inspect `.drift/upstream/<repo>` and prepare a PR per repo.
 
-          # 3. Clone the three upstream repos.
-          for r in elasticsearch beats integrations; do
-            git clone --depth 1 --filter=blob:none "https://github.com/elastic/\$r" "/tmp/\$r"
-          done
+          ## Manual intervention required for new EA fields
 
-          # 4. Regenerate the five mapping files in place.
-          stats-to-mapping \\
-          $recipe_paths
-              < /tmp/stats.json
+          The Elastic Agent integration package data stream is TSDB (`elasticsearch.index_mode: time_series`). Numeric fields on a TSDB stream need a `metric_type: gauge|counter` annotation so Fleet/EPM emits the corresponding `time_series_metric` ES mapping parameter, which drives downsampling semantics.
 
-          # 5. Inspect the resulting diffs and prepare upstream PRs.
-          for r in elasticsearch beats integrations; do
-            echo "=== \$r ==="
-            git -C "/tmp/\$r" diff
-          done
-          \`\`\`
+          The regen tool cannot derive `gauge` vs `counter` from `/stats` (which carries values only). It retains existing `metric_type:` annotations by name match, but every newly added field appears in the integrations diff with `metric_type: FIXME`. **Search the integrations diff for `FIXME` and replace each with `gauge` or `counter` (and a `description:`) before opening the upstream PR.**
 
           ## Resolution
 
@@ -253,7 +134,14 @@ jobs:
           RECIPE
           } > "$BODY"
           gh issue create --repo "$REPO" \
-            --title "stats-to-mapping drift in $DRIFTED_FILES file(s) ($today)" \
+            --title "stats-to-mapping drift in $drifted_files file(s) ($today)" \
             --label bug \
             --label "$DRIFT_LABEL" \
             --body-file "$BODY"
+
+      # Surface the script's exit status as the job's exit status. The
+      # script exits 1 on drift; without this step, the job would always
+      # be green because of continue-on-error above.
+      - name: Fail job if drift detected
+        if: steps.classify.outputs.drifted == 'true'
+        run: exit 1

--- a/.github/workflows/stats-to-mapping-drift.yml
+++ b/.github/workflows/stats-to-mapping-drift.yml
@@ -8,8 +8,6 @@ name: stats-to-mapping-drift
 # stats-to-mapping-drift`); this workflow wraps the script with
 # GitHub-Actions-specific concerns: artifact upload and drift-issue
 # creation.
-#
-# Background: elastic/apm-server#21000.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/stats-to-mapping-drift.yml
+++ b/.github/workflows/stats-to-mapping-drift.yml
@@ -1,5 +1,5 @@
 ---
-name: monitoring-metric-mapping-drift
+name: stats-to-mapping-drift
 
 # Weekly cron that detects drift between apm-server's /stats endpoint and the
 # upstream mapping files in elastic/elasticsearch, elastic/beats, and
@@ -27,7 +27,7 @@ jobs:
       contents: read
       issues: write
     env:
-      DRIFT_LABEL: monitoring-metrics-drift
+      DRIFT_LABEL: stats-to-mapping-drift
       WORK: ${{ github.workspace }}/.drift
       UPSTREAM_FILES: |
         elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json

--- a/.github/workflows/stats-to-mapping-drift.yml
+++ b/.github/workflows/stats-to-mapping-drift.yml
@@ -29,11 +29,12 @@ jobs:
     env:
       DRIFT_LABEL: stats-to-mapping-drift
       WORK: ${{ github.workspace }}/.drift
+      STATS_PORT: 15066
       # Single source of truth for the files this job tracks. Each line is
       # "<repo>/<path-within-repo>". The first slash-separated segment is
       # treated as the github.com/elastic/<repo> name; the remainder is the
       # file's path inside that repo. Sparse-checkout, the regen invocation,
-      # the drift loop, and the issue-body recipe are all derived from this.
+      # the drift loop, and the issue-body recipe all derive from this.
       UPSTREAM_FILES: |
         elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
         elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
@@ -55,11 +56,14 @@ jobs:
       - name: Install stats-to-mapping
         run: go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
 
-      - name: Run apm-server, capture /stats
+      # Write the apm-server config to a file. The same file is read back later
+      # to embed in the drift issue's reproduction recipe (with path.data
+      # rewritten), so the two can never drift.
+      - name: Write apm-server config
         run: |
           set -euo pipefail
           mkdir -p "$WORK/data"
-          install -m 0600 /dev/stdin "$WORK/apm-server.yml" <<'EOF'
+          install -m 0600 /dev/stdin "$WORK/apm-server.yml" <<EOF
           apm-server:
             host: "127.0.0.1:18200"
             sampling.tail:
@@ -69,27 +73,30 @@ jobs:
                 - sample_rate: 1
           output.elasticsearch:
             hosts: ["http://127.0.0.1:9200"]
-          path.data: ${WORK}/data
+          path.data: $WORK/data
           http.enabled: true
           http.host: "127.0.0.1"
-          http.port: 15066
+          http.port: $STATS_PORT
           logging.level: warning
           EOF
-          # Substitute $WORK because the heredoc was quoted.
-          sed -i "s|\${WORK}|$WORK|" "$WORK/apm-server.yml"
-          "$WORK/apm-server" --strict.perms=false -e -c "$WORK/apm-server.yml" >"$WORK/apm-server.log" 2>&1 &
-          echo $! > "$WORK/apm-server.pid"
+
+      - name: Run apm-server, capture /stats
+        run: |
+          set -euo pipefail
+          "$WORK/apm-server" --strict.perms=false -e -c "$WORK/apm-server.yml" \
+            >"$WORK/apm-server.log" 2>&1 &
+          pid=$!
+          trap 'kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null || true' EXIT
           for attempt in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:15066/stats -o "$WORK/stats.json"; then
+            if curl -sf "http://127.0.0.1:$STATS_PORT/stats" -o "$WORK/stats.json"; then
               echo "Captured /stats on attempt $attempt"
               break
             fi
             sleep 1
           done
-          kill "$(cat "$WORK/apm-server.pid")" || true
-          wait || true
           test -s "$WORK/stats.json"
-          # Sanity: TBS-enabled stats should contain sampling.tail.storage.
+          # TBS-enabled stats must include sampling.tail.storage.* — fail fast
+          # if the config or apm-server's stats shape changed.
           jq -e '.["apm-server"].sampling.tail.storage' "$WORK/stats.json" >/dev/null
 
       - name: Sparse-checkout upstream mapping files
@@ -124,7 +131,7 @@ jobs:
           set -euo pipefail
           : > "$WORK/drift.diff"
           : > "$WORK/drift.summary.md"
-          drift_found=false
+          drifted_files=0
           while IFS= read -r path; do
             [ -z "$path" ] && continue
             repo=${path%%/*}
@@ -133,7 +140,7 @@ jobs:
             if git -C "$tree" diff --quiet -- "$file"; then
               continue
             fi
-            drift_found=true
+            drifted_files=$((drifted_files + 1))
             read -r added removed _ < <(git -C "$tree" diff --numstat -- "$file")
             printf -- '- `%s/%s` — +%s / -%s\n' "$repo" "$file" "$added" "$removed" \
               >> "$WORK/drift.summary.md"
@@ -143,10 +150,10 @@ jobs:
               printf '\n```\n'
             } >> "$WORK/drift.diff"
           done <<< "$UPSTREAM_FILES"
-          echo "drift=$drift_found" >> "$GITHUB_OUTPUT"
+          echo "drifted_files=$drifted_files" >> "$GITHUB_OUTPUT"
 
       - name: Upload drift diff artifact
-        if: steps.drift.outputs.drift == 'true'
+        if: steps.drift.outputs.drifted_files != '0'
         uses: actions/upload-artifact@v4
         with:
           name: drift-diff
@@ -155,26 +162,45 @@ jobs:
             ${{ env.WORK }}/stats.json
           retention-days: 30
 
+      # If drift is detected and no open drift issue already exists, file a new
+      # issue. The issue body has three sections: a one-line summary, a list of
+      # drifted files, and a copy-pasteable local reproduction recipe.
+      #
+      # The apm-server config in the recipe is read back from the file written
+      # earlier in this job (with the CI-specific path.data rewritten) so the
+      # recipe and the CI run can never disagree about what config produced
+      # the captured /stats.
       - name: Open drift issue if none exists
-        if: steps.drift.outputs.drift == 'true'
+        if: steps.drift.outputs.drifted_files != '0'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DRIFTED_FILES: ${{ steps.drift.outputs.drifted_files }}
         run: |
           set -euo pipefail
-          existing=$(gh issue list --repo "$REPO" --label "$DRIFT_LABEL" --state open --json number --jq 'length')
+          existing=$(gh issue list --repo "$REPO" --label "$DRIFT_LABEL" \
+            --state open --json number --jq 'length')
           if [ "$existing" -gt 0 ]; then
             echo "Open drift issue already exists; not opening another"
             exit 0
           fi
+
           today=$(date -u +%Y-%m-%d)
+
+          # Build the path block for the recipe by prefixing each tracked file
+          # with /tmp/. Trailing backslashes continue the shell command.
           recipe_paths=$(printf '%s\n' "$UPSTREAM_FILES" \
-            | awk 'NF > 0 { print "    /tmp/" $0 " \\" }')
+            | awk 'NF > 0 { print "      /tmp/" $0 " \\" }')
+
+          # Reuse the exact apm-server config from the CI run, with path.data
+          # rewritten to the local /tmp location used in the recipe.
+          recipe_config=$(sed "s|$WORK/data|/tmp/apm-server-data|" "$WORK/apm-server.yml")
+
           BODY=$WORK/issue-body.md
           {
             cat <<HEADER
-          The weekly drift-check workflow detected divergence between apm-server's \`/stats\` endpoint and the upstream mapping files maintained in \`elastic/elasticsearch\`, \`elastic/beats\`, and \`elastic/integrations\`.
+          The weekly drift-check workflow detected drift in **$DRIFTED_FILES file(s)** between apm-server's \`/stats\` endpoint and the upstream mapping files in \`elastic/elasticsearch\`, \`elastic/beats\`, and \`elastic/integrations\`.
 
           Detected on $today by [workflow run]($RUN_URL). The full \`git diff\` of every drifted file is attached to that run as the \`drift-diff\` artifact, alongside the captured \`stats.json\`.
 
@@ -186,56 +212,48 @@ jobs:
 
           ## Reproduce locally
 
-          \`\`\`shell
-          # 1. Install the regen tool.
-          go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
+          From an apm-server checkout:
 
-          # 2. Build apm-server from main and capture a TBS-enabled /stats snapshot.
+          \`\`\`shell
+          # 1. Install the regen tool. Make sure \$(go env GOPATH)/bin is on PATH.
+          go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
+          export PATH="\$PATH:\$(go env GOPATH)/bin"
+
+          # 2. Build apm-server and capture a TBS-enabled /stats snapshot.
           go build -o /tmp/apm-server ./x-pack/apm-server
           install -m 0600 /dev/stdin /tmp/apm-server.yml <<'CFG'
-          apm-server:
-            host: "127.0.0.1:18200"
-            sampling.tail:
-              enabled: true
-              interval: 1m
-              policies:
-                - sample_rate: 1
-          output.elasticsearch:
-            hosts: ["http://127.0.0.1:9200"]
-          path.data: /tmp/apm-server-data
-          http.enabled: true
-          http.host: "127.0.0.1"
-          http.port: 15066
-          logging.level: warning
+          $recipe_config
           CFG
           /tmp/apm-server --strict.perms=false -e -c /tmp/apm-server.yml &
+          pid=\$!
           sleep 6
-          curl -s http://127.0.0.1:15066/stats > /tmp/stats.json
-          kill %1; wait || true
+          curl -s http://127.0.0.1:$STATS_PORT/stats > /tmp/stats.json
+          kill "\$pid"; wait "\$pid" 2>/dev/null || true
 
-          # 3. Clone the three upstream repos (sparse).
+          # 3. Clone the three upstream repos.
           for r in elasticsearch beats integrations; do
             git clone --depth 1 --filter=blob:none "https://github.com/elastic/\$r" "/tmp/\$r"
           done
 
-          # 4. Run the regen.
+          # 4. Regenerate the five mapping files in place.
           stats-to-mapping \\
           $recipe_paths
               < /tmp/stats.json
 
-          # 5. Inspect the diffs and prepare upstream PRs.
+          # 5. Inspect the resulting diffs and prepare upstream PRs.
           for r in elasticsearch beats integrations; do
-            echo "=== \$r ==="; git -C "/tmp/\$r" diff
+            echo "=== \$r ==="
+            git -C "/tmp/\$r" diff
           done
           \`\`\`
 
           ## Resolution
 
-          Open a PR in each upstream repo with the diffs above, then close this issue. The workflow will not open another issue while this one stays open.
+          Open a PR in each upstream repo with the diffs above, then close this issue. The workflow will not open another drift issue while this one stays open.
           RECIPE
           } > "$BODY"
           gh issue create --repo "$REPO" \
-            --title "Monitoring metric mappings drifted from /stats ($today)" \
+            --title "stats-to-mapping drift in $DRIFTED_FILES file(s) ($today)" \
             --label bug \
             --label "$DRIFT_LABEL" \
             --body-file "$BODY"

--- a/.github/workflows/stats-to-mapping-drift.yml
+++ b/.github/workflows/stats-to-mapping-drift.yml
@@ -231,9 +231,7 @@ jobs:
 
           ## Resolution
 
-          Open a PR in each upstream repo with the diffs above, then close this issue.
-
-          Tracked by #21000. This workflow will not open another issue while this one stays open.
+          Open a PR in each upstream repo with the diffs above, then close this issue. The workflow will not open another issue while this one stays open.
           RECIPE
           } > "$BODY"
           gh issue create --repo "$REPO" \

--- a/.github/workflows/stats-to-mapping-drift.yml
+++ b/.github/workflows/stats-to-mapping-drift.yml
@@ -29,6 +29,11 @@ jobs:
     env:
       DRIFT_LABEL: stats-to-mapping-drift
       WORK: ${{ github.workspace }}/.drift
+      # Single source of truth for the files this job tracks. Each line is
+      # "<repo>/<path-within-repo>". The first slash-separated segment is
+      # treated as the github.com/elastic/<repo> name; the remainder is the
+      # file's path inside that repo. Sparse-checkout, the regen invocation,
+      # the drift loop, and the issue-body recipe are all derived from this.
       UPSTREAM_FILES: |
         elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
         elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
@@ -91,28 +96,27 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$WORK/upstream"
-          clone() {
-            local repo=$1 path=$2
+          declare -A repo_paths
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            repo=${path%%/*}
+            repo_paths[$repo]+="${path#*/} "
+          done <<< "$UPSTREAM_FILES"
+          for repo in "${!repo_paths[@]}"; do
             git clone --depth 1 --filter=blob:none --no-checkout \
               "https://github.com/elastic/$repo" "$WORK/upstream/$repo"
             git -C "$WORK/upstream/$repo" sparse-checkout init --no-cone
-            git -C "$WORK/upstream/$repo" sparse-checkout set "$path"
+            # shellcheck disable=SC2086
+            git -C "$WORK/upstream/$repo" sparse-checkout set ${repo_paths[$repo]}
             git -C "$WORK/upstream/$repo" checkout
-          }
-          clone elasticsearch  x-pack/plugin/core/template-resources/src/main/resources
-          clone beats          metricbeat/module/beat
-          clone integrations   packages/elastic_agent/data_stream/apm_server_metrics
+          done
 
       - name: Run stats-to-mapping
         run: |
           set -euo pipefail
-          stats-to-mapping \
-            "$WORK/upstream/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json" \
-            "$WORK/upstream/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json" \
-            "$WORK/upstream/beats/metricbeat/module/beat/_meta/fields.yml" \
-            "$WORK/upstream/beats/metricbeat/module/beat/stats/_meta/fields.yml" \
-            "$WORK/upstream/integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml" \
-            < "$WORK/stats.json"
+          mapfile -t paths < <(printf '%s\n' "$UPSTREAM_FILES" \
+            | awk -v w="$WORK" 'NF > 0 { print w "/upstream/" $0 }')
+          stats-to-mapping "${paths[@]}" < "$WORK/stats.json"
 
       - name: Compute drift per file
         id: drift
@@ -125,21 +129,19 @@ jobs:
             [ -z "$path" ] && continue
             repo=${path%%/*}
             file=${path#*/}
-            cd "$WORK/upstream/$repo"
-            if git diff --quiet -- "$file"; then
-              cd - >/dev/null
+            tree="$WORK/upstream/$repo"
+            if git -C "$tree" diff --quiet -- "$file"; then
               continue
             fi
             drift_found=true
-            added=$(git diff --numstat -- "$file" | awk '{print $1}')
-            removed=$(git diff --numstat -- "$file" | awk '{print $2}')
-            printf -- '- `%s/%s` — +%s / -%s\n' "$repo" "$file" "$added" "$removed" >> "$WORK/drift.summary.md"
+            read -r added removed _ < <(git -C "$tree" diff --numstat -- "$file")
+            printf -- '- `%s/%s` — +%s / -%s\n' "$repo" "$file" "$added" "$removed" \
+              >> "$WORK/drift.summary.md"
             {
               printf '\n## %s/%s\n\n```diff\n' "$repo" "$file"
-              git diff -- "$file"
+              git -C "$tree" diff -- "$file"
               printf '\n```\n'
             } >> "$WORK/drift.diff"
-            cd - >/dev/null
           done <<< "$UPSTREAM_FILES"
           echo "drift=$drift_found" >> "$GITHUB_OUTPUT"
 
@@ -167,6 +169,8 @@ jobs:
             exit 0
           fi
           today=$(date -u +%Y-%m-%d)
+          recipe_paths=$(printf '%s\n' "$UPSTREAM_FILES" \
+            | awk 'NF > 0 { print "    /tmp/" $0 " \\" }')
           BODY=$WORK/issue-body.md
           {
             cat <<HEADER
@@ -216,12 +220,8 @@ jobs:
 
           # 4. Run the regen.
           stats-to-mapping \\
-            /tmp/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json \\
-            /tmp/elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json \\
-            /tmp/beats/metricbeat/module/beat/_meta/fields.yml \\
-            /tmp/beats/metricbeat/module/beat/stats/_meta/fields.yml \\
-            /tmp/integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml \\
-            < /tmp/stats.json
+          $recipe_paths
+              < /tmp/stats.json
 
           # 5. Inspect the diffs and prepare upstream PRs.
           for r in elasticsearch beats integrations; do

--- a/.github/workflows/stats-to-mapping-drift.yml
+++ b/.github/workflows/stats-to-mapping-drift.yml
@@ -43,7 +43,7 @@ jobs:
         integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml
     steps:
       - name: Checkout apm-server
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,16 @@ system-test:
 	# would only work on the parts that don't involve APM Server binary.
 	@(cd systemtest; go test $(GOMODFLAG) $(GOTESTFLAGS) -tags=grpcnotrace,pebblegozstd,$(GOTAGS) -race -timeout=20m ./...)
 
+# stats-to-mapping-drift detects divergence between this checkout's /stats
+# endpoint and the upstream mapping files in elastic/elasticsearch,
+# elastic/beats, and elastic/integrations. Same script the
+# stats-to-mapping-drift CI workflow runs; run it locally to reproduce a
+# drift issue's diffs without waiting for the next Monday cron. See
+# script/stats-to-mapping-drift.sh for the orchestration.
+.PHONY: stats-to-mapping-drift
+stats-to-mapping-drift:
+	@bash script/stats-to-mapping-drift.sh
+
 .PHONY:
 clean:
 	@rm -rf build apm-server apm-server.exe apm-server-oss apm-server-fips

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,8 @@ system-test:
 
 # stats-to-mapping-drift detects divergence between this checkout's /stats
 # endpoint and the upstream mapping files in elastic/elasticsearch,
-# elastic/beats, and elastic/integrations. Same script the
-# stats-to-mapping-drift CI workflow runs; run it locally to reproduce a
-# drift issue's diffs without waiting for the next Monday cron.
-#
-# Depends on the apm-server binary at the repo root (built by `make
-# apm-server`). See script/stats-to-mapping-drift.sh for the rest.
+# elastic/beats, and elastic/integrations. See
+# script/stats-to-mapping-drift.sh.
 .PHONY: stats-to-mapping-drift
 stats-to-mapping-drift: apm-server
 	@bash script/stats-to-mapping-drift.sh

--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,12 @@ system-test:
 # endpoint and the upstream mapping files in elastic/elasticsearch,
 # elastic/beats, and elastic/integrations. Same script the
 # stats-to-mapping-drift CI workflow runs; run it locally to reproduce a
-# drift issue's diffs without waiting for the next Monday cron. See
-# script/stats-to-mapping-drift.sh for the orchestration.
+# drift issue's diffs without waiting for the next Monday cron.
+#
+# Depends on the apm-server binary at the repo root (built by `make
+# apm-server`). See script/stats-to-mapping-drift.sh for the rest.
 .PHONY: stats-to-mapping-drift
-stats-to-mapping-drift:
+stats-to-mapping-drift: apm-server
 	@bash script/stats-to-mapping-drift.sh
 
 .PHONY:

--- a/script/stats-to-mapping-drift.sh
+++ b/script/stats-to-mapping-drift.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # Detect drift between apm-server's /stats endpoint and the upstream
 # mapping files in elastic/elasticsearch, elastic/beats, and
-# elastic/integrations.
+# elastic/integrations. Run via `make stats-to-mapping-drift` (which
+# builds the apm-server binary first via the apm-server target);
+# invoking the script directly assumes ./apm-server already exists.
 #
 # Steps:
-#   1. Build apm-server (or reuse a prebuilt binary at $APM_SERVER_BIN).
-#   2. Start it with TBS enabled and capture /stats.
-#   3. Install the regen tool (github.com/elastic/apm-tools/cmd/stats-to-mapping).
-#   4. Sparse-clone the three upstream repos.
-#   5. Run the regen tool over the five tracked files.
-#   6. Compute per-file git diff and a summary.
+#   1. Start ./apm-server with TBS enabled and capture /stats.
+#   2. Install the regen tool (github.com/elastic/apm-tools/cmd/stats-to-mapping).
+#   3. Sparse-clone the three upstream repos.
+#   4. Run the regen tool over the five tracked files.
+#   5. Compute per-file git diff and a summary.
 #
 # Outputs (relative to $WORK, default .drift/):
 #   apm-server.yml         apm-server config used to capture stats
@@ -25,7 +26,7 @@ set -euo pipefail
 
 WORK=${WORK:-.drift}
 STATS_PORT=${STATS_PORT:-15066}
-APM_SERVER_BIN=${APM_SERVER_BIN:-}
+APM_SERVER_BIN=${APM_SERVER_BIN:-./apm-server}
 
 # UPSTREAM_FILES is the single source of truth for the files this script
 # tracks. Each line is "<repo>/<path-within-repo>". Sparse-checkout, the
@@ -41,14 +42,13 @@ EOF
 
 mkdir -p "$WORK/data"
 
-# 1. Build apm-server unless a binary was provided.
-if [ -z "$APM_SERVER_BIN" ]; then
-  echo "==> Building apm-server"
-  go build -o "$WORK/apm-server" ./x-pack/apm-server
-  APM_SERVER_BIN="$WORK/apm-server"
+if [ ! -x "$APM_SERVER_BIN" ]; then
+  echo "apm-server binary not found at $APM_SERVER_BIN" >&2
+  echo "Run \`make apm-server\` first, or invoke this script via \`make stats-to-mapping-drift\`." >&2
+  exit 1
 fi
 
-# 2. Write config and start apm-server. The same config is reused below
+# 1. Write config and start apm-server. The same config is reused below
 # when generating the recipe in any drift issue, so there's a single
 # source of truth.
 echo "==> Writing apm-server config"
@@ -86,12 +86,12 @@ test -s "$WORK/stats.json"
 # the config or apm-server's stats shape changed.
 jq -e '.["apm-server"].sampling.tail.storage' "$WORK/stats.json" >/dev/null
 
-# 3. Install the regen tool. $(go env GOPATH)/bin must be on PATH.
+# 2. Install the regen tool. $(go env GOPATH)/bin must be on PATH.
 echo "==> Installing stats-to-mapping"
 go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
 export PATH="$PATH:$(go env GOPATH)/bin"
 
-# 4. Sparse-clone the three upstream repos. Group UPSTREAM_FILES lines by
+# 3. Sparse-clone the three upstream repos. Group UPSTREAM_FILES lines by
 # repo so each repo is cloned once with all its tracked paths.
 echo "==> Cloning upstream repos"
 mkdir -p "$WORK/upstream"
@@ -114,13 +114,13 @@ for repo in "${!repo_paths[@]}"; do
   git -C "$WORK/upstream/$repo" checkout
 done
 
-# 5. Run the regen tool over the five tracked files.
+# 4. Run the regen tool over the five tracked files.
 echo "==> Running stats-to-mapping"
 mapfile -t paths < <(printf '%s\n' "$UPSTREAM_FILES" \
   | awk -v w="$WORK" 'NF > 0 { print w "/upstream/" $0 }')
 stats-to-mapping "${paths[@]}" < "$WORK/stats.json"
 
-# 6. Compute per-file drift.
+# 5. Compute per-file drift.
 echo "==> Computing drift"
 : > "$WORK/drift.diff"
 : > "$WORK/drift.summary.md"

--- a/script/stats-to-mapping-drift.sh
+++ b/script/stats-to-mapping-drift.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Detect drift between apm-server's /stats endpoint and the upstream
+# mapping files in elastic/elasticsearch, elastic/beats, and
+# elastic/integrations.
+#
+# Steps:
+#   1. Build apm-server (or reuse a prebuilt binary at $APM_SERVER_BIN).
+#   2. Start it with TBS enabled and capture /stats.
+#   3. Install the regen tool (github.com/elastic/apm-tools/cmd/stats-to-mapping).
+#   4. Sparse-clone the three upstream repos.
+#   5. Run the regen tool over the five tracked files.
+#   6. Compute per-file git diff and a summary.
+#
+# Outputs (relative to $WORK, default .drift/):
+#   apm-server.yml         apm-server config used to capture stats
+#   apm-server.log         apm-server stdout/stderr
+#   stats.json             captured /stats document
+#   upstream/<repo>/...    sparse clones of the three upstream repos
+#   drift.diff             full git diff of every drifted file
+#   drift.summary.md       per-file `<repo>/<file> — +N / -M` bullets
+#
+# Exit code: 0 if no drift, 1 if drift detected.
+
+set -euo pipefail
+
+WORK=${WORK:-.drift}
+STATS_PORT=${STATS_PORT:-15066}
+APM_SERVER_BIN=${APM_SERVER_BIN:-}
+
+# UPSTREAM_FILES is the single source of truth for the files this script
+# tracks. Each line is "<repo>/<path-within-repo>". Sparse-checkout, the
+# regen invocation, and the drift loop all derive from this.
+UPSTREAM_FILES=$(cat <<'EOF'
+elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
+elasticsearch/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
+beats/metricbeat/module/beat/_meta/fields.yml
+beats/metricbeat/module/beat/stats/_meta/fields.yml
+integrations/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml
+EOF
+)
+
+mkdir -p "$WORK/data"
+
+# 1. Build apm-server unless a binary was provided.
+if [ -z "$APM_SERVER_BIN" ]; then
+  echo "==> Building apm-server"
+  go build -o "$WORK/apm-server" ./x-pack/apm-server
+  APM_SERVER_BIN="$WORK/apm-server"
+fi
+
+# 2. Write config and start apm-server. The same config is reused below
+# when generating the recipe in any drift issue, so there's a single
+# source of truth.
+echo "==> Writing apm-server config"
+install -m 0600 /dev/stdin "$WORK/apm-server.yml" <<EOF
+apm-server:
+  host: "127.0.0.1:18200"
+  sampling.tail:
+    enabled: true
+    interval: 1m
+    policies:
+      - sample_rate: 1
+output.elasticsearch:
+  hosts: ["http://127.0.0.1:9200"]
+path.data: $WORK/data
+http.enabled: true
+http.host: "127.0.0.1"
+http.port: $STATS_PORT
+logging.level: warning
+EOF
+
+echo "==> Capturing /stats"
+"$APM_SERVER_BIN" --strict.perms=false -e -c "$WORK/apm-server.yml" \
+  >"$WORK/apm-server.log" 2>&1 &
+pid=$!
+trap 'kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null || true' EXIT
+for attempt in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:$STATS_PORT/stats" -o "$WORK/stats.json"; then
+    echo "    captured on attempt $attempt"
+    break
+  fi
+  sleep 1
+done
+test -s "$WORK/stats.json"
+# TBS-enabled stats must include sampling.tail.storage.* — fail fast if
+# the config or apm-server's stats shape changed.
+jq -e '.["apm-server"].sampling.tail.storage' "$WORK/stats.json" >/dev/null
+
+# 3. Install the regen tool. $(go env GOPATH)/bin must be on PATH.
+echo "==> Installing stats-to-mapping"
+go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
+export PATH="$PATH:$(go env GOPATH)/bin"
+
+# 4. Sparse-clone the three upstream repos. Group UPSTREAM_FILES lines by
+# repo so each repo is cloned once with all its tracked paths.
+echo "==> Cloning upstream repos"
+mkdir -p "$WORK/upstream"
+declare -A repo_paths
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  repo=${path%%/*}
+  repo_paths[$repo]+="${path#*/} "
+done <<< "$UPSTREAM_FILES"
+for repo in "${!repo_paths[@]}"; do
+  if [ -d "$WORK/upstream/$repo/.git" ]; then
+    echo "    $repo: already cloned, skipping"
+    continue
+  fi
+  git clone --depth 1 --filter=blob:none --no-checkout \
+    "https://github.com/elastic/$repo" "$WORK/upstream/$repo"
+  git -C "$WORK/upstream/$repo" sparse-checkout init --no-cone
+  # shellcheck disable=SC2086
+  git -C "$WORK/upstream/$repo" sparse-checkout set ${repo_paths[$repo]}
+  git -C "$WORK/upstream/$repo" checkout
+done
+
+# 5. Run the regen tool over the five tracked files.
+echo "==> Running stats-to-mapping"
+mapfile -t paths < <(printf '%s\n' "$UPSTREAM_FILES" \
+  | awk -v w="$WORK" 'NF > 0 { print w "/upstream/" $0 }')
+stats-to-mapping "${paths[@]}" < "$WORK/stats.json"
+
+# 6. Compute per-file drift.
+echo "==> Computing drift"
+: > "$WORK/drift.diff"
+: > "$WORK/drift.summary.md"
+drifted=0
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  repo=${path%%/*}
+  file=${path#*/}
+  tree="$WORK/upstream/$repo"
+  if git -C "$tree" diff --quiet -- "$file"; then
+    continue
+  fi
+  drifted=$((drifted + 1))
+  read -r added removed _ < <(git -C "$tree" diff --numstat -- "$file")
+  printf -- '- `%s/%s` — +%s / -%s\n' "$repo" "$file" "$added" "$removed" \
+    >> "$WORK/drift.summary.md"
+  {
+    printf '\n## %s/%s\n\n```diff\n' "$repo" "$file"
+    git -C "$tree" diff -- "$file"
+    printf '\n```\n'
+  } >> "$WORK/drift.diff"
+done <<< "$UPSTREAM_FILES"
+
+if [ "$drifted" -eq 0 ]; then
+  echo "==> No drift"
+  exit 0
+fi
+echo "==> Drift detected in $drifted file(s):"
+cat "$WORK/drift.summary.md"
+echo
+echo "Full diff: $WORK/drift.diff"
+exit 1

--- a/script/stats-to-mapping-drift.sh
+++ b/script/stats-to-mapping-drift.sh
@@ -48,9 +48,7 @@ if [ ! -x "$APM_SERVER_BIN" ]; then
   exit 1
 fi
 
-# 1. Write config and start apm-server. The same config is reused below
-# when generating the recipe in any drift issue, so there's a single
-# source of truth.
+# 1. Write config and start apm-server.
 echo "==> Writing apm-server config"
 install -m 0600 /dev/stdin "$WORK/apm-server.yml" <<EOF
 apm-server:

--- a/script/stats-to-mapping-drift.sh
+++ b/script/stats-to-mapping-drift.sh
@@ -72,14 +72,21 @@ echo "==> Capturing /stats"
   >"$WORK/apm-server.log" 2>&1 &
 pid=$!
 trap 'kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null || true' EXIT
+captured=false
 for attempt in $(seq 1 30); do
   if curl -sf "http://127.0.0.1:$STATS_PORT/stats" -o "$WORK/stats.json"; then
     echo "    captured on attempt $attempt"
+    captured=true
     break
   fi
   sleep 1
 done
-test -s "$WORK/stats.json"
+if ! $captured; then
+  echo "Failed to capture /stats from http://127.0.0.1:$STATS_PORT after 30 attempts." >&2
+  echo "Last 50 lines of apm-server log:" >&2
+  tail -50 "$WORK/apm-server.log" >&2 || true
+  exit 1
+fi
 # TBS-enabled stats must include sampling.tail.storage.* — fail fast if
 # the config or apm-server's stats shape changed.
 jq -e '.["apm-server"].sampling.tail.storage' "$WORK/stats.json" >/dev/null

--- a/script/stats-to-mapping-drift.sh
+++ b/script/stats-to-mapping-drift.sh
@@ -7,7 +7,8 @@
 #
 # Steps:
 #   1. Start ./apm-server with TBS enabled and capture /stats.
-#   2. Install the regen tool (github.com/elastic/apm-tools/cmd/stats-to-mapping).
+#   2. Shallow-clone elastic/apm-tools and build cmd/stats-to-mapping
+#      into $WORK; nothing is installed into $GOPATH/bin.
 #   3. Sparse-clone the three upstream repos.
 #   4. Run the regen tool over the five tracked files.
 #   5. Compute per-file git diff and a summary.
@@ -16,6 +17,9 @@
 #   apm-server.yml         apm-server config used to capture stats
 #   apm-server.log         apm-server stdout/stderr
 #   stats.json             captured /stats document
+#   apm-tools/             shallow clone of elastic/apm-tools
+#                          (skipped when $APM_TOOLS_DIR is set)
+#   stats-to-mapping       compiled regen tool binary
 #   upstream/<repo>/...    sparse clones of the three upstream repos
 #   drift.diff             full git diff of every drifted file
 #   drift.summary.md       per-file `<repo>/<file> — +N / -M` bullets
@@ -91,10 +95,20 @@ fi
 # the config or apm-server's stats shape changed.
 jq -e '.["apm-server"].sampling.tail.storage' "$WORK/stats.json" >/dev/null
 
-# 2. Install the regen tool. $(go env GOPATH)/bin must be on PATH.
-echo "==> Installing stats-to-mapping"
-go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest
-export PATH="$PATH:$(go env GOPATH)/bin"
+# 2. Build the regen tool from apm-tools. Built into $WORK so the
+# developer/CI environment's $GOPATH/bin is not polluted. Set
+# APM_TOOLS_DIR to point at an existing local apm-tools checkout to
+# skip the shallow clone (useful when iterating on the regen tool).
+APM_TOOLS_DIR=${APM_TOOLS_DIR:-$WORK/apm-tools}
+if [ ! -d "$APM_TOOLS_DIR" ]; then
+  echo "==> Cloning elastic/apm-tools"
+  git clone --depth 1 https://github.com/elastic/apm-tools "$APM_TOOLS_DIR"
+fi
+echo "==> Building stats-to-mapping (from $APM_TOOLS_DIR)"
+# Resolve to an absolute path so `go build -C` can write to it regardless
+# of what working directory go itself ends up in.
+STATS_TO_MAPPING=$(realpath -m "$WORK/stats-to-mapping")
+go build -C "$APM_TOOLS_DIR" -o "$STATS_TO_MAPPING" ./cmd/stats-to-mapping
 
 # 3. Sparse-clone the three upstream repos. Group UPSTREAM_FILES lines by
 # repo so each repo is cloned once with all its tracked paths.
@@ -123,7 +137,7 @@ done
 echo "==> Running stats-to-mapping"
 mapfile -t paths < <(printf '%s\n' "$UPSTREAM_FILES" \
   | awk -v w="$WORK" 'NF > 0 { print w "/upstream/" $0 }')
-stats-to-mapping "${paths[@]}" < "$WORK/stats.json"
+"$STATS_TO_MAPPING" "${paths[@]}" < "$WORK/stats.json"
 
 # 5. Compute per-file drift.
 echo "==> Computing drift"


### PR DESCRIPTION
## Motivation/summary

Implements the scheduled drift-detection job proposed in #21000 — the part of that issue that catches drift between apm-server's `/stats` endpoint and the five upstream mapping files when nobody has manually run the regen tool. The active-developer side of the same issue is implemented in [elastic/apm-tools#245](https://github.com/elastic/apm-tools/pull/245); this PR is the CI side.

## How and when it runs

A single new workflow at `.github/workflows/stats-to-mapping-drift.yml`. Triggers:

- `schedule: cron: '0 6 * * MON'` — every Monday at 06:00 UTC.
- `workflow_dispatch` — on-demand from the Actions tab or `gh workflow run`.

Each run, in order:

1. Builds apm-server from the workflow's checked-out commit (`go build ./x-pack/apm-server`).
2. Installs the regen tool: `go install github.com/elastic/apm-tools/cmd/stats-to-mapping@latest`.
3. Starts apm-server with TBS enabled and captures `/stats` from the `http.enabled` endpoint, then stops apm-server. The captured `stats.json` is the source of truth for the comparison.
4. Sparse-clones the three upstream repos (`elastic/elasticsearch`, `elastic/beats`, `elastic/integrations`) with `--depth 1 --filter=blob:none` and `sparse-checkout`, so only the relevant subtrees materialise.
5. Runs the regen tool over the five tracked files, then `git diff`s each one to detect drift.

`UPSTREAM_FILES` (job-level env) is the single source of truth for the file list: the sparse-checkout, the regen invocation, the drift loop, and the recipe in the issue body all derive from it. Adding or removing a tracked file means editing one list.

The apm-server config used to capture `/stats` is written to a file in the CI run and then read back (with `path.data` rewritten) when generating the recipe, so the issue's repro recipe and the CI run cannot disagree about what config produced the captured `/stats`.

## What the run produces

If no file drifted, the workflow exits green with no other output.

If at least one file drifted:

- **Workflow artifact** `drift-diff` (30-day retention) — full `git diff` of every drifted file, plus the captured `stats.json`.
- **Issue** with labels `bug` + `stats-to-mapping-drift`, body containing:
  - One-line summary stating how many files drifted and linking the workflow run.
  - Per-file change summary (`<repo>/<path> — +N / -M`).
  - A copy-pasteable local reproduction recipe (apm-server build, /stats capture, three upstream clones, regen invocation).

The issue is opened only if no open issue with the `stats-to-mapping-drift` label already exists. A sustained drift event therefore produces one issue, not a weekly stream of duplicates.

## Permissions

- Workflow level: `contents: read`.
- `drift-check` job: `contents: read` plus `issues: write` (required only to file the drift issue). No write access to the codebase, no PR creation, no other scopes.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc) — n/a, internal CI.
- [ ] Documentation has been updated — workflow has a header comment that points at #21000.

## How to test these changes

After merge, trigger the workflow manually from the Actions tab (`workflow_dispatch`). With current upstream state and a /stats capture from `main`, the workflow is expected to detect drift and file one issue.

Locally, run the recipe written into a generated drift issue's body to obtain the same diffs.

## Related issues

- Implements the CI piece of #21000.
- Pairs with [elastic/apm-tools#245](https://github.com/elastic/apm-tools/pull/245). The cron's first run will fail at `go install ...stats-to-mapping@latest` until that PR is merged; the cron is not scheduled to fire until the next Monday after merge.
- Adjacent to #20993, which makes `/stats` an exhaustive enumeration of every counter apm-server defines. Without it, the workflow would compare an incomplete `/stats` against the upstream files and produce false positives.
