### PR TITLE
perf: Use nil pebble iter option

### DIFF
--- a/x-pack/apm-server/sampling/eventstorage/prefix.go
+++ b/x-pack/apm-server/sampling/eventstorage/prefix.go
@@ -62,7 +62,7 @@ func (rw PrefixReadWriter) ReadTraceEventsCallback(traceID string, softMemoryLim
 	b.WriteString(traceID)
 	b.WriteByte(traceIDSeparator)
 
-	iter, err := rw.db.NewIter(&pebble.IterOptions{})
+	iter, err := rw.db.NewIter(nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Pass in a nil pebble iter option to reduce alloc. It has the same effect as a pointer to empty option.
Minor change, no changelog needed.

According to pebble docs
> IterOptions hold the optional per-query parameters for NewIter.
Like Options, a nil *IterOptions is valid and means to use the default values

benchstat
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage
cpu: AMD Ryzen 7 PRO 8840HS w/ Radeon 780M Graphics 
                                 │   ptr.out   │              nil.out               │
                                 │   sec/op    │   sec/op     vs base               │
ReadEvents/nop_codec/0_events-16   851.9n ± 3%   673.5n ± 4%  -20.94% (p=0.002 n=6)

                                 │  ptr.out   │              nil.out              │
                                 │    B/op    │    B/op     vs base               │
ReadEvents/nop_codec/0_events-16   537.0 ± 0%   152.0 ± 0%  -71.69% (p=0.002 n=6)

                                 │  ptr.out   │              nil.out              │
                                 │ allocs/op  │ allocs/op   vs base               │
ReadEvents/nop_codec/0_events-16   6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.002 n=6)
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Documentation has been updated~~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

No test needed, covered by existing automated tests

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
