### PR TITLE
cloud: tag resources with keep-until

### DIFF
--- a/testing/infra/terraform/modules/tags/output.tf
+++ b/testing/infra/terraform/modules/tags/output.tf
@@ -7,6 +7,7 @@ locals {
     "build" : var.build
     "ephemeral" : "true"
     "expiration_date" : formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))
+    "keep-until" : formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))
   }
 }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

This tag will help us destroy things automatically,  let's keep the expiration_date also for backward compatibility


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
