### PR TITLE
add release notes for v9.3.6 and v9.4.3

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -24,6 +24,14 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [apm-next-fixes]
 % * 1 sentence describing the change. ([#PR number](https://github.com/elastic/apm-server/pull/PR number))
 
+## 9.4.3 [apm-9.4.3-release-notes]
+
+_No new features, enhancements, or fixes._
+
+## 9.4.2 [apm-9.4.2-release-notes]
+
+_No new features, enhancements, or fixes._
+
 ## 9.4.1 [apm-9.4.1-release-notes]
 
 ### Fixes [apm-9.4.1-fixes]
@@ -39,6 +47,16 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ### Fixes [apm-9.4.0-fixes]
 
 * Fixed HTTP/2 connections being dropped by strict clients and browser-based RUM agents due to APM Server sending inconsistent SETTINGS frames at connection start. ([#20913](https://github.com/elastic/apm-server/pull/20913)). For more details, refer to our known issues [page](https://www.elastic.co/docs/release-notes/apm/known-issues)
+
+## 9.3.6 [apm-9.3.6-release-notes]
+
+_No new features, enhancements, or fixes._
+
+## 9.3.5 [apm-9.3.5-release-notes]
+
+### Fixes [apm-9.3.5-fixes]
+
+* Bound Tail-Based Sampling memory usage when reading sampled trace events by implementing paging ([#20881](https://github.com/elastic/apm-server/pull/20881))
 
 ## 9.3.4 [apm-9.3.4-release-notes]
 


### PR DESCRIPTION
As it says on the tin. Additionally, also adds the missing changelogs for v9.3.5 and v9.4.2