### PR TITLE
Revert "9.4.4: update versions"

### DIFF
--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "9.4.4"
+const version = "9.4.3"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "9.4.4"
+const Version = "9.4.3"


### PR DESCRIPTION
Reverts elastic/apm-server#21246 as the PR was merged before version release. No tags are pushed (only DRAs) so we should be good 🤞 