### PR TITLE
smoke: remove Rocky Linux 8 from supported OS matrix

### DIFF
--- a/testing/smoke/os_matrix.sh
+++ b/testing/smoke/os_matrix.sh
@@ -8,7 +8,8 @@ os_names=(
     "al2023-ami-2023"
     "RHEL-8"
     "RHEL-9"
-    "Rocky-8-EC2-Base"
+    # Rocky Linux 8 removed for now.
+    # See https://github.com/elastic/apm-server/issues/21179
     "Rocky-9-EC2-Base"
     "AlmaLinux OS 8"
     "AlmaLinux OS 9"

--- a/testing/smoke/os_matrix.sh
+++ b/testing/smoke/os_matrix.sh
@@ -8,8 +8,7 @@ os_names=(
     "al2023-ami-2023"
     "RHEL-8"
     "RHEL-9"
-    # Rocky Linux 8 removed for now.
-    # See https://github.com/elastic/apm-server/issues/21179
+    # "Rocky-8-EC2-Base" # See https://github.com/elastic/apm-server/issues/21179
     "Rocky-9-EC2-Base"
     "AlmaLinux OS 8"
     "AlmaLinux OS 9"


### PR DESCRIPTION
## Motivation/summary

Follow-up to #21247.

`standalone_apm_server` removed Rocky Linux 8 AMI mappings, but `testing/smoke/os_matrix.sh` still included `Rocky-8-EC2-Base`, causing smoke test failures when Terraform indexed missing map keys. This PR removes Rocky Linux 8 from the smoke OS matrix to keep smoke coverage aligned with available AMIs.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- From branch head, inspect `testing/smoke/os_matrix.sh` and verify `Rocky-8-EC2-Base` is not present.
- Run smoke test script and confirm matrix iteration no longer includes Rocky Linux 8:
  - `testing/smoke/supported-os/test.sh <version>`

## Related issues

- Follow-up to https://github.com/elastic/apm-server/pull/21247
- Related: https://github.com/elastic/apm-server/issues/21179

Made with [Cursor](https://cursor.com)