### PR TITLE
Add release notes for v9.3.7

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -48,6 +48,10 @@ _No new features, enhancements, or fixes._
 
 * Fixed HTTP/2 connections being dropped by strict clients and browser-based RUM agents due to APM Server sending inconsistent SETTINGS frames at connection start. ([#20913](https://github.com/elastic/apm-server/pull/20913)). For more details, refer to our known issues [page](https://www.elastic.co/docs/release-notes/apm/known-issues)
 
+## 9.3.7 [apm-9.3.7-release-notes]
+
+_No new features, enhancements, or fixes._
+
 ## 9.3.6 [apm-9.3.6-release-notes]
 
 _No new features, enhancements, or fixes._


### PR DESCRIPTION
## Summary
- Add the `9.3.7` section to APM release notes in `docs/release-notes/index.md`
- Document that `v9.3.7` has no user-facing features, enhancements, or fixes
- This is based on review of commits between `v9.3.6` and `v9.3.7`, filtering out release-engineering, infra, and test-only changes

## Test plan
- [x] Inspect commits in `v9.3.6..v9.3.7`
- [x] Confirm release notes file renders with the new `9.3.7` heading and content
- [ ] Docs CI passes

Made with [Cursor](https://cursor.com)