### PR TITLE
ci: Update benchmark default system profiles to aws

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -89,7 +89,7 @@ jobs:
       TF_VAR_apm_server_tail_sampling_sample_rate: ${{ inputs.tailSamplingSampleRate || '0.1' }} # set the default again otherwise schedules won't work
       RUN_STANDALONE: ${{ inputs.runStandalone || github.event.schedule=='0 0 1 * *' }}
       PGO_EXPORT: ${{ inputs.pgoExport || github.event.schedule=='0 0 1 * *' }}
-      TFVARS_SOURCE: ${{ inputs.profile || 'system-profiles/8GBx1zone.tfvars' }} # set the default again otherwise schedules won't work
+      TFVARS_SOURCE: ${{ inputs.profile || 'system-profiles/8GBx1zone-aws.tfvars' }} # set the default again otherwise schedules won't work
       TF_VAR_BUILD_ID: ${{ github.run_id }}
       TF_VAR_ENVIRONMENT: ci
       TF_VAR_REPO: ${{ github.repository }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Update nightly benchmark default system profile to AWS instead of GCP because QA CFT region is in AWS. Fixes docker image override issue on ECH e.g. https://github.com/elastic/apm-server/actions/runs/28536331778/attempts/1
```
│ Error: failed creating deployment: 2 errors occurred:
│ 	* api error: clusters.cluster_plan_change_prohibited: The requested cluster configuration change is not permitted. Value of field 'elasticsearch.docker_image' cannot be changed to [***/cloud-release/elasticsearch-cloud-ess:9.5.0-6d00cfc8-SNAPSHOT]. (resources.elasticsearch[0].elasticsearch.docker_image)
│ 	* set "request_id" to "hr7eez95g7pzdnbq5kvj3j2hyhbqm6re04ypbt9wvpreusi5857nq2imkwvvxeet" to recreate the deployment resources
│ 
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follow up to https://github.com/elastic/apm-server/pull/21274