### PR TITLE
ci: expect new version in run-patch-release to fix off-by-1

### DIFF
--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The new patch release version (semver: major.minor.patch). Example: if releasing 9.3.1, use 9.3.1.'
+        description: 'The new patch release version (semver: major.minor.patch). Example: if versions should be bumped to 9.3.1, use 9.3.1.'
         required: true
         type: string
 

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -60,16 +60,6 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.get_token.outputs.token }}
 
-      - id: bump_version
-        shell: bash
-        run: |
-          VERSION="${{ needs.prepare.outputs.release-version }}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
-          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
       # Required to use a service account, otherwise PRs created by
       # GitHub bot won't trigger any CI builds.
       # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
@@ -89,7 +79,7 @@ jobs:
       - run: make patch-release
         env:
           GH_TOKEN: ${{ steps.get_token.outputs.token }}
-          BUMP_VERSION: ${{ steps.bump_version.outputs.version }}
+          BUMP_VERSION: ${{ needs.prepare.outputs.release-version }}
 
       - if: success()
         uses: elastic/oblt-actions/slack/send@v1
@@ -97,7 +87,7 @@ jobs:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ env.SLACK_CHANNEL }}
           message: |-
-            PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ steps.bump_version.outputs.version }}` have been created.
+            PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ needs.prepare.outputs.release-version }}` have been created.
             Remember to create PRs for the changelogs separately!
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -88,6 +88,7 @@ jobs:
           channel-id: ${{ env.SLACK_CHANNEL }}
           message: |-
             PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ needs.prepare.outputs.release-version }}` have been created.
+            Open release PRs: https://github.com/elastic/apm-server/pulls?q=is%3Apr+is%3Aopen+label%3Arelease
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 
       - if: failure()

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -88,7 +88,7 @@ jobs:
           channel-id: ${{ env.SLACK_CHANNEL }}
           message: |-
             PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ needs.prepare.outputs.release-version }}` have been created.
-            Open release PRs: https://github.com/elastic/apm-server/pulls?q=is%3Apr+is%3Aopen+label%3Arelease
+            :pr: <https://github.com/elastic/apm-server/pulls?q=is%3Apr+is%3Aopen+label%3Arelease|Open release PRs>
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 
       - if: failure()

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The current to-be-released version (semver format: major.minor.patch). E.g. If the feature freeze / release for 9.3.1 is coming, use 9.3.1.'
+        description: 'The target patch release version (semver: major.minor.patch). Example: if releasing 9.3.1, use 9.3.1.'
         required: true
         type: string
 

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The target patch release version (semver: major.minor.patch). Example: if releasing 9.3.1, use 9.3.1.'
+        description: 'The new patch release version (semver: major.minor.patch). Example: if releasing 9.3.1, use 9.3.1.'
         required: true
         type: string
 

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -88,7 +88,6 @@ jobs:
           channel-id: ${{ env.SLACK_CHANNEL }}
           message: |-
             PRs to bump versions in `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch to `${{ needs.prepare.outputs.release-version }}` have been created.
-            Remember to create PRs for the changelogs separately!
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 
       - if: failure()

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -1,6 +1,6 @@
 # APM Server Release Checklist
 
-The APM Server follows the Elastic Stack release schedule and versions. A release starts with a Feature Freeze period, during which only bug fixes are allowed to be merged into the specific release branch. We generally follow [semver](https://semver.org/) for release versions. For major and minor releases, a new branch is cut from the main branch. For patch releases, only the version on the existing major and minor version branch gets updated. All release workflows (patch, minor, major) has to be triggered manually. The Release Manager will ping the team to align the release process.
+The APM Server follows the Elastic Stack release schedule and versions. A release starts with a Feature Freeze period, during which only bug fixes are allowed to be merged into the specific release branch. We generally follow [semver](https://semver.org/) for release versions. For major and minor releases, a new branch is cut from the main branch. For patch releases, only the version on the existing major and minor version branch gets updated. Major and minor release workflows are triggered manually, while patch releases are usually triggered through the centralized version bump pipeline. The Release Manager will ping the team to align the release process.
 
 This documentation is for 9.x releases. If you are releasing a 8.x look [here](./RELEASES_8x.md)
 
@@ -8,10 +8,10 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
 
 1. Create a *Test Plan*.
 2. Ensure all relevant backport PRs are merged. We use backport labels on PRs and automation to ensure labels are set.
-3. Run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow
-    - In "Use workflow from", select `main` branch.
-    - Then in "The version", specify the **new** patch release version, e.g.: if versions should be bumped to `9.3.2`, use `9.3.2`.
-    - This workflow is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump).
+3. Trigger patch version bump automation.
+    - For patch releases, this is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump), and then triggers [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) with the new version.
+    - If needed, you can still run `run-patch-release` manually from `main`.
+    - In "The version", specify the **new** patch release version, e.g.: if versions should be bumped to `9.3.2`, use `9.3.2`.
     - This workflow will:
         - Create the `update-<VERSION>` branch for the provided version.
         - Update version constants across the codebase and create a PR targeting the release branch.

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -8,7 +8,7 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
 
 1. Create a *Test Plan*.
 2. Ensure all relevant backport PRs are merged. We use backport labels on PRs and automation to ensure labels are set.
-3. Trigger patch version bump automation.
+3. Ensure patch version bump automation has run for the release version.
     - For patch releases, this is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump), and then triggers [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) with the new version.
     - If needed, you can still run `run-patch-release` manually from `main`.
     - In "The version", specify the **new** patch release version, e.g.: if versions should be bumped to `9.3.2`, use `9.3.2`.

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -10,7 +10,7 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
 2. Ensure all relevant backport PRs are merged. We use backport labels on PRs and automation to ensure labels are set.
 3. Release notes for patch releases **must be manually added** at least one day before release.
 4. Create a PR targeting the `main` branch. To add release notes:
-    - Add a new section to the existing release notes file ([Sample PR](https://github.com/elastic/apm-server/pull/20723)) containing the `Features and enchancements` as well as the `Fixes` subsections.
+    - Add a new section to the existing release notes file ([Sample PR](https://github.com/elastic/apm-server/pull/20723)) containing the `Features and enhancements` as well as the `Fixes` subsections.
     - Add your PR to the documentation release issue in the [`elastic/dev`](https://github.com/elastic/dev/issues?q=is%3Aissue%20state%3Aopen%20label%3Adocs) repo ([Sample Issue](https://github.com/elastic/dev/issues/3467)).
     - The PR should be merged the day before release.
 5. On release day, ensure patch version bump automation has run for the release version.

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -10,9 +10,10 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
 2. Ensure all relevant backport PRs are merged. We use backport labels on PRs and automation to ensure labels are set.
 3. Run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow
     - In "Use workflow from", select `main` branch.
-    - Then in "The version", specify the **upcoming** patch release version, e.g.: on `9.3.2` feature freeze you will use `9.3.2`).
+    - Then in "The version", specify the **target/new** patch release version, e.g.: on `9.3.2` feature freeze you will use `9.3.2`.
+    - This workflow is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump).
     - This workflow will:
-        - Create the `update-<VERSION>` branch.
+        - Create the `update-<VERSION>` branch for the provided version.
         - Update version constants across the codebase and create a PR targeting the release branch.
 4. Release notes for patch releases **must be manually added** at least one day before release.
 5. Create a PR targeting the `main` branch. To add release notes:

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -10,7 +10,7 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
 2. Ensure all relevant backport PRs are merged. We use backport labels on PRs and automation to ensure labels are set.
 3. Run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow
     - In "Use workflow from", select `main` branch.
-    - Then in "The version", specify the **target/new** patch release version, e.g.: on `9.3.2` feature freeze you will use `9.3.2`.
+    - Then in "The version", specify the **new** patch release version, e.g.: if versions should be bumped to `9.3.2`, use `9.3.2`.
     - This workflow is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump).
     - This workflow will:
         - Create the `update-<VERSION>` branch for the provided version.

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -10,6 +10,7 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
 2. Ensure all relevant backport PRs are merged. We use backport labels on PRs and automation to ensure labels are set.
 3. Ensure patch version bump automation has run for the release version.
     - For patch releases, this is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump), and then triggers [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) with the new version.
+    - This automated patch bump is usually executed on release day.
     - If needed, you can still run `run-patch-release` manually from `main`.
     - In "The version", specify the **new** patch release version, e.g.: if versions should be bumped to `9.3.2`, use `9.3.2`.
     - This workflow will:
@@ -28,6 +29,7 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
     - Create a new release branch using the stack version (X.Y).
     - Update the changelog for the release branch and open a PR targeting the release branch titled `<major>.<minor>: update docs`.
     - Create a PR on `main` titled `<major>.<minor>: update docs, mergify, versions and changelogs`.
+    - Automated minor version bumps are typically done on Feature Freeze day.
 
 ## Major Release
 

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -1,6 +1,6 @@
 # APM Server Release Checklist
 
-The APM Server follows the Elastic Stack release schedule and versions. A release starts with a Feature Freeze period, during which only bug fixes are allowed to be merged into the specific release branch. We generally follow [semver](https://semver.org/) for release versions. For major and minor releases, a new branch is cut from the main branch. For patch releases, only the version on the existing major and minor version branch gets updated. Major and minor release workflows are triggered manually, while patch releases are usually triggered through the centralized version bump pipeline. The Release Manager will ping the team to align the release process.
+The APM Server follows the Elastic Stack release schedule and versions. A release starts with a Feature Freeze period, during which only bug fixes are allowed to be merged into the specific release branch. We generally follow [semver](https://semver.org/) for release versions. For major and minor releases, a new branch is cut from the main branch. For patch releases, only the version on the existing major and minor version branch gets updated. Release workflows can be run manually, and version bump automation is often driven by the centralized release pipeline (typically minor on Feature Freeze day and patch on release day). The Release Manager will ping the team to align the release process.
 
 This documentation is for 9.x releases. If you are releasing a 8.x look [here](./RELEASES_8x.md)
 

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -8,7 +8,12 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
 
 1. Create a *Test Plan*.
 2. Ensure all relevant backport PRs are merged. We use backport labels on PRs and automation to ensure labels are set.
-3. Ensure patch version bump automation has run for the release version.
+3. Release notes for patch releases **must be manually added** at least one day before release.
+4. Create a PR targeting the `main` branch. To add release notes:
+    - Add a new section to the existing release notes file ([Sample PR](https://github.com/elastic/apm-server/pull/20723)) containing the `Features and enchancements` as well as the `Fixes` subsections.
+    - Add your PR to the documentation release issue in the [`elastic/dev`](https://github.com/elastic/dev/issues?q=is%3Aissue%20state%3Aopen%20label%3Adocs) repo ([Sample Issue](https://github.com/elastic/dev/issues/3467)).
+    - The PR should be merged the day before release.
+5. On release day, ensure patch version bump automation has run for the release version.
     - For patch releases, this is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump), and then triggers [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) with the new version.
     - This automated patch bump is usually executed on release day.
     - If needed, you can still run `run-patch-release` manually from `main`.
@@ -16,11 +21,6 @@ This documentation is for 9.x releases. If you are releasing a 8.x look [here](.
     - This workflow will:
         - Create the `update-<VERSION>` branch for the provided version.
         - Update version constants across the codebase and create a PR targeting the release branch.
-4. Release notes for patch releases **must be manually added** at least one day before release.
-5. Create a PR targeting the `main` branch. To add release notes:
-    - Add a new section to the existing release notes file ([Sample PR](https://github.com/elastic/apm-server/pull/20723)) containing the `Features and enchancements` as well as the `Fixes` subsections.
-    - Add your PR to the documentation release issue in the [`elastic/dev`](https://github.com/elastic/dev/issues?q=is%3Aissue%20state%3Aopen%20label%3Adocs) repo ([Sample Issue](https://github.com/elastic/dev/issues/3467)).
-    - The PR should be merged the day before release.
 
 ## Minor Release
 

--- a/dev_docs/RELEASES_8x.md
+++ b/dev_docs/RELEASES_8x.md
@@ -4,13 +4,13 @@ We expect no more minor versions in the `8.x` line after 8.19, but only patch re
 
 ## 8.17 patch releases
 
-Run the `run-patch-release` with any `8.17.x` version.
+Run the `run-patch-release` with the target/new `8.17.x` patch version.
 
 **NOTE**: This automation does not handle the changelog, which should be manually handled.
 
 ## 8.18 patch releases
 
-Run the `run-patch-release` with any `8.18.x` version.
+Run the `run-patch-release` with the target/new `8.18.x` patch version.
 
 **NOTE**: This automation does not handle the changelog, which should be manually handled.
 
@@ -41,7 +41,7 @@ Refer to `release.mk` and the `minor-release` target for further details.
 
 ## 8.19 patch releases
 
-Run the `run-patch-release` with any `8.19.x` version.
+Run the `run-patch-release` with the target/new `8.19.x` patch version.
 
 **NOTE**: This automation does not handle the changelog, which should be manually handled.
 
@@ -57,9 +57,10 @@ Run the `run-patch-release` with any `8.19.x` version.
 * Trigger release workflow manually
   * For **patch releases**: run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow. In "Use workflow from", specify the following values:
        * Branch: Select the relevant `8.x` branch - e.g: `8.14` for `8.14.x` patch releases.
-       * Version: Specify the **upcoming** patch release version - e.g: on `8.14.2` feature freeze you will use `8.14.2`.
+       * Version: Specify the **target/new** patch release version - e.g: on `8.14.2` feature freeze you will use `8.14.2`.
+       * This workflow is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump).
    
-    This workflow will: create the `update-<VERSION>` branch, update version constants across the codebase and create a PR targeting the release branch.
+    This workflow will: create the `update-<VERSION>` branch for the provided version, update version constants across the codebase and create a PR targeting the release branch.
     
     Release notes for patch releases **must be manually added** at least one day before release.
     Create a PR targeting the relevant `8.x` branch.

--- a/dev_docs/RELEASES_8x.md
+++ b/dev_docs/RELEASES_8x.md
@@ -4,13 +4,13 @@ We expect no more minor versions in the `8.x` line after 8.19, but only patch re
 
 ## 8.17 patch releases
 
-Run the `run-patch-release` with the target/new `8.17.x` patch version.
+Run the `run-patch-release` with the new `8.17.x` patch version.
 
 **NOTE**: This automation does not handle the changelog, which should be manually handled.
 
 ## 8.18 patch releases
 
-Run the `run-patch-release` with the target/new `8.18.x` patch version.
+Run the `run-patch-release` with the new `8.18.x` patch version.
 
 **NOTE**: This automation does not handle the changelog, which should be manually handled.
 
@@ -41,7 +41,7 @@ Refer to `release.mk` and the `minor-release` target for further details.
 
 ## 8.19 patch releases
 
-Run the `run-patch-release` with the target/new `8.19.x` patch version.
+Run the `run-patch-release` with the new `8.19.x` patch version.
 
 **NOTE**: This automation does not handle the changelog, which should be manually handled.
 
@@ -57,7 +57,7 @@ Run the `run-patch-release` with the target/new `8.19.x` patch version.
 * Trigger release workflow manually
   * For **patch releases**: run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow. In "Use workflow from", specify the following values:
        * Branch: Select the relevant `8.x` branch - e.g: `8.14` for `8.14.x` patch releases.
-       * Version: Specify the **target/new** patch release version - e.g: on `8.14.2` feature freeze you will use `8.14.2`.
+       * Version: Specify the **new** patch release version - e.g: if versions should be bumped to `8.14.2`, use `8.14.2`.
        * This workflow is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump).
    
     This workflow will: create the `update-<VERSION>` branch for the provided version, update version constants across the codebase and create a PR targeting the release branch.

--- a/dev_docs/RELEASES_8x.md
+++ b/dev_docs/RELEASES_8x.md
@@ -54,11 +54,11 @@ Run the `run-patch-release` with the new `8.19.x` patch version.
 
 ## Day after Feature Freeze
 
-* Trigger release workflow manually
-  * For **patch releases**: run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow. In "Use workflow from", specify the following values:
+* Trigger release automation
+  * For **patch releases**, this is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump), and then triggers [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) with the new version.
+  * If needed, you can still run `run-patch-release` manually. In "Use workflow from", specify the following values:
        * Branch: Select the relevant `8.x` branch - e.g: `8.14` for `8.14.x` patch releases.
        * Version: Specify the **new** patch release version - e.g: if versions should be bumped to `8.14.2`, use `8.14.2`.
-       * This workflow is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump).
    
     This workflow will: create the `update-<VERSION>` branch for the provided version, update version constants across the codebase and create a PR targeting the release branch.
     

--- a/dev_docs/RELEASES_8x.md
+++ b/dev_docs/RELEASES_8x.md
@@ -55,7 +55,8 @@ Run the `run-patch-release` with the new `8.19.x` patch version.
 ## Day after Feature Freeze
 
 * Trigger release automation
-  * For **patch releases**, this is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump), and then triggers [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) with the new version.
+  * For **minor releases**, automated version bumps are usually done on Feature Freeze day.
+  * For **patch releases**, this is usually triggered by [unified-release-centralized-version-bump](https://buildkite.com/elastic/unified-release-centralized-version-bump), which calls [apm-server-version-bump](https://buildkite.com/elastic/apm-server-version-bump), and then triggers [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) with the new version on release day.
   * If needed, you can still run `run-patch-release` manually. In "Use workflow from", specify the following values:
        * Branch: Select the relevant `8.x` branch - e.g: `8.14` for `8.14.x` patch releases.
        * Version: Specify the **new** patch release version - e.g: if versions should be bumped to `8.14.2`, use `8.14.2`.


### PR DESCRIPTION
## Motivation/summary

Patch release automation was using `patch + 1` instead of the provided version, which caused version-bump PRs to target the wrong patch version.

This PR fixes that by passing the provided release version directly to `make patch-release`, and aligns workflow/docs wording with the current centralized release flow.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

1. Trigger `run-patch-release` with an explicit patch version (example: `9.4.1`).
2. Verify the workflow runs `make patch-release` with `BUMP_VERSION=9.4.1` (not `9.4.2`).
3. Verify the generated version bump PR title/target corresponds to the provided version.
4. Confirm the success Slack message reports the provided release version and includes the release PRs link.

## Related issues

Closes #21043