### PR TITLE
Unify branch existence validation in prepare-release action

### DIFF
--- a/.github/workflows/prepare-release/action.yml
+++ b/.github/workflows/prepare-release/action.yml
@@ -76,7 +76,7 @@ runs:
     - name: validate if branch already exists (major or minor only)
       if: ${{ inputs.type == 'major' || inputs.type == 'minor' }}
       run: |-
-        if git ls-remote --exit-code --heads "https://github.com/${GITHUB_REPOSITORY}.git" "$BRANCH" > /dev/null ; then
+        if git ls-remote --exit-code --heads https://github.com/${{ github.repository }}.git "$BRANCH" > /dev/null ; then
           FAILURE_MESSAGE="Branch already exists. This is not a ${RELEASE_TYPE} release."
           echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
           echo "::error::${FAILURE_MESSAGE}" ; exit 1

--- a/.github/workflows/prepare-release/action.yml
+++ b/.github/workflows/prepare-release/action.yml
@@ -73,29 +73,18 @@ runs:
         echo "::error::${FAILURE_MESSAGE}" ; exit 1
       shell: 'bash'
 
-    - name: validate if branch already exists (major only)
-      if: ${{ inputs.type == 'major' }}
+    - name: validate if branch already exists (major or minor only)
+      if: ${{ inputs.type == 'major' || inputs.type == 'minor' }}
       run: |-
         if git ls-remote --exit-code --heads "https://github.com/${GITHUB_REPOSITORY}.git" "$BRANCH" > /dev/null ; then
+          FAILURE_MESSAGE="Branch already exists. This is not a ${RELEASE_TYPE} release."
           echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
           echo "::error::${FAILURE_MESSAGE}" ; exit 1
         fi
       shell: 'bash'
       env:
         BRANCH: ${{ steps.generate.outputs.release-branch }}
-        FAILURE_MESSAGE: Branch already exists. This is not a major release.
-
-    - name: validate if branch already exists (minor only)
-      if: ${{ inputs.type == 'minor' }}
-      run: |-
-        if git ls-remote --exit-code --heads https://github.com/${{ github.repository }}.git "$BRANCH" > /dev/null ; then
-          FAILURE_MESSAGE='Branch already exists. This is not a minor release.'
-          echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
-          echo "::error::${FAILURE_MESSAGE}" ; exit 1
-        fi
-      shell: 'bash'
-      env:
-        BRANCH: ${{ steps.generate.outputs.release-branch }}
+        RELEASE_TYPE: ${{ inputs.type }}
 
     - name: validate if tag already exists
       run: |-


### PR DESCRIPTION
## Summary
- Merge the duplicate major and minor branch-existence checks in `prepare-release` into a single step
- Keep release-type-specific error messaging via `RELEASE_TYPE`
- Step title clarifies it runs for major or minor releases only

## Test plan
- [ ] Verify `prepare-release` composite action YAML is valid
- [ ] Confirm major/minor release workflows still invoke the action unchanged

Notifies https://github.com/elastic/observability-robots/issues/3404