### PR TITLE
test: Fix flaky TestStoageMonitoring

### DIFF
--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -677,6 +677,8 @@ func TestStorageMonitoring(t *testing.T) {
 	})
 	require.NoError(t, err)
 	go processor.Run()
+	defer processor.Stop(context.Background())
+
 	for i := 0; i < 100; i++ {
 		traceID := uuid.Must(uuid.NewV4()).String()
 		batch := modelpb.Batch{{
@@ -693,11 +695,11 @@ func TestStorageMonitoring(t *testing.T) {
 		assert.Empty(t, batch)
 	}
 
-	// Stop the processor, flushing pending writes.
-	err = processor.Stop(context.Background())
-	require.NoError(t, err)
-
-	require.NoError(t, config.DB.Flush())
+	// Wait for cached db size update
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lsm, _ := config.DB.Size()
+		assert.Greater(c, lsm, int64(0))
+	}, 2*time.Second, 20*time.Millisecond)
 
 	metricsNames := []string{
 		"apm-server.sampling.tail.storage.lsm_size",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Fix flaky TestStorageMonitoring by fixing race that assertion happens before processor.Run goroutine hits db size update.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes https://github.com/elastic/apm-server/issues/20944
