### PR TITLE
[8.19] test: Fix flaky TestStorageMonitoring

### DIFF
--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -129,13 +129,14 @@ func TestStorageMonitoring(t *testing.T) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		gaugeValues := getGaugeValues(c, reader, metricsNames...)
+		require.Len(t, gaugeValues, len(metricsNames))
 
 		lsmSize := gaugeValues[0]
 		vlogSize := gaugeValues[1]
-		assert.Greater(c, lsmSize+vlogSize, int64(10000))
+		assert.Greater(c, lsmSize+vlogSize, int64(10000), "lsm_size + value_log_size")
 		storageLimit := gaugeValues[2]
-		assert.EqualValues(c, 270000, storageLimit)
-	}, 2*time.Second, 100*time.Millisecond)
+		assert.Equal(c, int64(270000), storageLimit, "storage_limit")
+	}, 2*time.Second, 50*time.Millisecond)
 }
 
 func newTempdirConfig(tb testing.TB) (sampling.Config, sdkmetric.Reader) {

--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -108,25 +108,34 @@ func TestStorageMonitoring(t *testing.T) {
 	// Reopening storage is necessary to immediately recalculate the
 	// storage size, otherwise we must wait for a minute (hard-coded in
 	// badger) for storage metrics to be updated.
-	err = processor.Stop(context.Background())
+	err = processor.Stop(t.Context())
 	require.NoError(t, err)
 	require.NoError(t, closeBadger())
 	badgerDB, err = getBadgerDB(cfg.StorageDir, cfg.MeterProvider)
 	require.NoError(t, err)
+
+	// Run processor again to report storage limit
+	cfg.DB = badgerDB
+	processorNew, err := sampling.NewProcessor(cfg, logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+	go processorNew.Run()
+	defer processorNew.Stop(context.Background())
 
 	metricsNames := []string{
 		"apm-server.sampling.tail.storage.lsm_size",
 		"apm-server.sampling.tail.storage.value_log_size",
 		"apm-server.sampling.tail.storage.storage_limit",
 	}
-	gaugeValues := getGaugeValues(t, reader, metricsNames...)
 
-	lsmSize := gaugeValues[0]
-	assert.NotZero(t, lsmSize)
-	vlogSize := gaugeValues[1]
-	assert.NotZero(t, vlogSize)
-	storageLimit := gaugeValues[2]
-	assert.EqualValues(t, 270000, storageLimit)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		gaugeValues := getGaugeValues(c, reader, metricsNames...)
+
+		lsmSize := gaugeValues[0]
+		vlogSize := gaugeValues[1]
+		assert.Greater(c, lsmSize+vlogSize, int64(10000))
+		storageLimit := gaugeValues[2]
+		assert.EqualValues(c, 270000, storageLimit)
+	}, 2*time.Second, 100*time.Millisecond)
 }
 
 func newTempdirConfig(tb testing.TB) (sampling.Config, sdkmetric.Reader) {
@@ -181,7 +190,7 @@ func newTempdirConfig(tb testing.TB) (sampling.Config, sdkmetric.Reader) {
 //
 // It is helpful to provide multiple names for synchronous metrics to avoid losing data when collecting.
 // Observable metrics report everytime Collect is called, so there will be no data loss.
-func getGaugeValues(t testing.TB, reader sdkmetric.Reader, names ...string) []int64 {
+func getGaugeValues(t assert.TestingT, reader sdkmetric.Reader, names ...string) []int64 {
 	var rm metricdata.ResourceMetrics
 	assert.NoError(t, reader.Collect(context.Background(), &rm))
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Fix flaky TestStorageMonitoring in 8.19 branch. Fix a race where storage manager is stopped and not running and therefore storage limit is not reported


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #20944
