### PR TITLE
test: Fix TestStorageMonitoring to assert properly

### DIFF
--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -705,7 +705,7 @@ func TestStorageMonitoring(t *testing.T) {
 	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		gaugeValues := getGaugeValues(c, tempdirConfig.metricReader, metricsNames...)
-		require.Len(c, gaugeValues, 6)
+		require.Len(c, gaugeValues, len(metricsNames))
 
 		lsmSize := gaugeValues[0]
 		assert.Greater(c, lsmSize, float64(2000), "lsm_size")

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -642,7 +642,7 @@ func TestGroupsMonitoring(t *testing.T) {
 //
 // It is helpful to provide multiple names for synchronous metrics to avoid losing data when collecting.
 // Observable metrics report everytime Collect is called, so there will be no data loss.
-func getGaugeValues(t testing.TB, reader sdkmetric.Reader, names ...string) []float64 {
+func getGaugeValues(t assert.TestingT, reader sdkmetric.Reader, names ...string) []float64 {
 	var rm metricdata.ResourceMetrics
 	assert.NoError(t, reader.Collect(context.Background(), &rm))
 
@@ -690,16 +690,10 @@ func TestStorageMonitoring(t *testing.T) {
 				Sampled: true,
 			},
 		}}
-		err := processor.ProcessBatch(context.Background(), &batch)
+		err := processor.ProcessBatch(t.Context(), &batch)
 		require.NoError(t, err)
 		assert.Empty(t, batch)
 	}
-
-	// Wait for cached db size update
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		lsm, _ := config.DB.Size()
-		assert.Greater(c, lsm, int64(0))
-	}, 2*time.Second, 20*time.Millisecond)
 
 	metricsNames := []string{
 		"apm-server.sampling.tail.storage.lsm_size",
@@ -709,14 +703,24 @@ func TestStorageMonitoring(t *testing.T) {
 		"apm-server.sampling.tail.storage.disk_total",
 		"apm-server.sampling.tail.storage.disk_usage_threshold_pct",
 	}
-	gaugeValues := getGaugeValues(t, tempdirConfig.metricReader, metricsNames...)
-	assert.Len(t, gaugeValues, 6)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		gaugeValues := getGaugeValues(c, tempdirConfig.metricReader, metricsNames...)
+		require.Len(c, gaugeValues, 6)
 
-	lsmSize := gaugeValues[0]
-	assert.NotZero(t, lsmSize)
+		lsmSize := gaugeValues[0]
+		assert.Greater(c, lsmSize, float64(2000), "lsm_size")
 
-	vlogSize := gaugeValues[1]
-	assert.Zero(t, vlogSize)
+		vlogSize := gaugeValues[1]
+		assert.Zero(c, vlogSize, "value_log_size")
+
+		assert.Zero(c, gaugeValues[2], "storage_limit")
+		assert.NotZero(c, gaugeValues[3], "disk_used")
+		assert.NotZero(c, gaugeValues[4], "disk_total")
+
+		// TODO: known issue: disk_usage_threshold_pct not reported
+		// See https://github.com/elastic/apm-server/issues/20996
+		assert.Zero(c, gaugeValues[5], "disk_usage_threshold_pct")
+	}, 2*time.Second, 50*time.Millisecond)
 }
 
 func TestStorageLimit(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

9.x TestStorageMonitoring was not flaky, and https://github.com/elastic/apm-server/pull/21364 was not necessary, but it was not asserting the metrics correctly.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follow up to https://github.com/elastic/apm-server/pull/21364
