### PR TITLE
fix(fips): resolve failing stig check

### DIFF
--- a/packaging/docker/Dockerfile.fips
+++ b/packaging/docker/Dockerfile.fips
@@ -64,7 +64,7 @@ ENV BEAT_STRICT_PERMS=false
 # of system software without explicit privileged status." but this requirement does not
 # always apply cleanly to all base images, particularly Chainguard Static.
 # Since /usr/lib contains no files, the check fails, so we add an empty root-owned file to satisfy it.
-COPY --chmod=0644 --chown=0:0 --from=builder /src/empty /usr/lib/empty
+COPY --chmod=0755 --chown=0:0 --from=builder /src/empty /usr/lib/empty
 
 COPY --chmod=0644 --chown=nonroot:nonroot licenses/ELASTIC-LICENSE-2.0.txt /licenses/
 COPY --chmod=0644 --chown=nonroot:nonroot NOTICE-fips.txt /licenses/NOTICE.txt

--- a/packaging/docker/Dockerfile.fips
+++ b/packaging/docker/Dockerfile.fips
@@ -17,6 +17,7 @@ RUN --mount=type=cache,target=/root/go/pkg/mod \
 COPY --chmod=0644 apm-server-fips.yml ./apm-server.yml
 RUN sed -i 's/127.0.0.1:8200/0.0.0.0:8200/' apm-server.yml
 RUN sed -i 's/localhost:9200/elasticsearch:9200/' apm-server.yml
+RUN rm -f empty && touch empty
 
 ################################################################################
 # Build stage 1
@@ -58,6 +59,12 @@ ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
 # Disable libbeat's strict permissions checking, which is not relevant when
 # running in Docker.
 ENV BEAT_STRICT_PERMS=false
+
+# STIG V-203716 requires that "The operating system must prohibit user installation
+# of system software without explicit privileged status." but this requirement does not
+# always apply cleanly to all base images, particularly Chainguard Static.
+# Since /usr/lib contains no files, the check fails, so we add an empty root-owned file to satisfy it.
+COPY --chmod=0644 --chown=0:0 --from=builder /src/empty /usr/lib/empty
 
 COPY --chmod=0644 --chown=nonroot:nonroot licenses/ELASTIC-LICENSE-2.0.txt /licenses/
 COPY --chmod=0644 --chown=nonroot:nonroot NOTICE-fips.txt /licenses/NOTICE.txt


### PR DESCRIPTION
## Motivation/summary


```
# STIG V-203716 requires that "The operating system must prohibit user installation
# of system software without explicit privileged status." but this requirement does not
# always apply cleanly to all base images, particularly Chainguard Static.
# Since /usr/lib contains no files, the check fails, so we add an empty root-owned file to satisfy it.
```

sigh 

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Follow up to #20995
