### PR TITLE
[9.3] makefile: refactor DEFAULT_TAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ GOTESTFLAGS?=-v
 
 # Prevent unintended modifications of go.[mod|sum]
 GOMODFLAG?=-mod=readonly
+DEFAULT_TAGS=grpcnotrace,pebblegozstd
 
 PYTHON_ENV?=.
 PYTHON_VENV_DIR:=$(PYTHON_ENV)/build/ve/$(shell go env GOOS)
@@ -81,7 +82,7 @@ $(APM_SERVER_BINARIES):
 .PHONY: apm-server-build
 apm-server-build:
 	env CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0 \
-	go build -o "build/apm-server-$(GOOS)-$(GOARCH)$(SUFFIX)$(EXTENSION)" -trimpath $(GOFLAGS) -tags=grpcnotrace,pebblegozstd,$(GOTAGS) $(GOMODFLAG) -ldflags "$(LDFLAGS)" $(PKG)
+	go build -o "build/apm-server-$(GOOS)-$(GOARCH)$(SUFFIX)$(EXTENSION)" -trimpath $(GOFLAGS) -tags=$(DEFAULT_TAGS),$(GOTAGS) $(GOMODFLAG) -ldflags "$(LDFLAGS)" $(PKG)
 
 build/apm-server-linux-% build/apm-server-fips-linux-%: GOOS=linux
 build/apm-server-darwin-%: GOOS=darwin
@@ -125,13 +126,13 @@ apm-server apm-server-oss apm-server-fips apm-server-fips-msft:
 
 .PHONY: test
 test:
-	@go test $(GOMODFLAG) $(GOTESTFLAGS) -tags=grpcnotrace,pebblegozstd,$(GOTAGS) -race ./...
+	@go test $(GOMODFLAG) $(GOTESTFLAGS) -tags=$(DEFAULT_TAGS),$(GOTAGS) -race ./...
 
 .PHONY: system-test
 system-test:
 	# CGO is disabled when building APM Server binary, so the race detector in this case
 	# would only work on the parts that don't involve APM Server binary.
-	@(cd systemtest; go test $(GOMODFLAG) $(GOTESTFLAGS) -tags=grpcnotrace,pebblegozstd,$(GOTAGS) -race -timeout=20m ./...)
+	@(cd systemtest; go test $(GOMODFLAG) $(GOTESTFLAGS) -tags=$(DEFAULT_TAGS),$(GOTAGS) -race -timeout=20m ./...)
 
 .PHONY:
 clean:
@@ -278,10 +279,10 @@ gofmt: add-headers
 ##############################################################################
 
 MODULE_DEPS=$(sort $(shell \
-  CGO_ENABLED=0 go list -deps -tags=darwin,linux,windows,grpcnotrace,pebblegozstd -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}" ./x-pack/apm-server))
+  CGO_ENABLED=0 go list -deps -tags=darwin,linux,windows,$(DEFAULT_TAGS) -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}" ./x-pack/apm-server))
 
 MODULE_DEPS_FIPS=$(sort $(shell \
-  CGO_ENABLED=1 go list -deps -tags=linux,requirefips,grpcnotrace,pebblegozstd -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}" ./x-pack/apm-server))
+  CGO_ENABLED=1 go list -deps -tags=linux,requirefips,$(DEFAULT_TAGS) -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}" ./x-pack/apm-server))
 
 notice: NOTICE.txt NOTICE-fips.txt
 NOTICE.txt build/dependencies-$(APM_SERVER_VERSION).csv: go.mod


### PR DESCRIPTION
## Motivation/summary

The Makefile repeats the same `grpcnotrace,pebblegozstd` tag list in multiple build, test, and dependency-discovery targets, which makes future tag updates easy to miss and apply inconsistently.

This refactors those call sites to use a shared `DEFAULT_TAGS` variable, so tag changes can be made in one place while preserving existing behavior on `9.3`.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

## How to test these changes

1. Check the branch diff:
   - `git diff origin/9.3...HEAD -- Makefile`
   - Expected: `DEFAULT_TAGS=grpcnotrace,pebblegozstd` is introduced and used in build/test/notice tag arguments.
2. Verify make target expansion references the shared variable:
   - `make -n apm-server-build test system-test notice`
   - Expected: generated commands use `-tags=$(DEFAULT_TAGS),$(GOTAGS)` (and corresponding notice `go list` tags), with no functional changes beyond refactoring.

## Related issues

N/A

Made with [Cursor](https://cursor.com)