### PR TITLE
changelog: Add 8.19.19

### DIFF
--- a/changelogs/8.19.asciidoc
+++ b/changelogs/8.19.asciidoc
@@ -1,5 +1,6 @@
 [[apm-release-notes-8.19]]
 == APM version 8.19
+* <<apm-release-notes-8.19.19>>
 * <<apm-release-notes-8.19.18>>
 * <<apm-release-notes-8.19.17>>
 * <<apm-release-notes-8.19.16>>
@@ -19,6 +20,14 @@
 * <<apm-release-notes-8.19.2>>
 * <<apm-release-notes-8.19.1>>
 * <<apm-release-notes-8.19.0>>
+
+[float]
+[[apm-release-notes-8.19.19]]
+=== APM version 8.19.19
+
+https://github.com/elastic/apm-server/compare/v8.19.18\...v8.19.19[View commits]
+
+No significant changes.
 
 [float]
 [[apm-release-notes-8.19.18]]


### PR DESCRIPTION
## Motivation/summary

The 8.19.19 release has no significant APM Server changes documented yet.

Add a release-note entry that explicitly records no significant changes and links to the 8.19.18-to-8.19.19 comparison.

## Checklist

- [x] Documentation has been updated

## How to test these changes

## Related issues