### PR TITLE
ci: target QA Elastic Cloud for integration server test

### DIFF
--- a/.github/workflows/generate-upgrade-paths/script.sh
+++ b/.github/workflows/generate-upgrade-paths/script.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 cd integrationservertest
 
-SNAPSHOT_UPGRADE_PATHS=$(go run ./scripts/genpath --target='pro' --snapshots=true)
-BC_UPGRADE_PATHS=$(go run ./scripts/genpath --target='pro' --snapshots=false)
+SNAPSHOT_UPGRADE_PATHS=$(go run ./scripts/genpath --target='qa' --snapshots=true)
+BC_UPGRADE_PATHS=$(go run ./scripts/genpath --target='qa' --snapshots=false)
 
 echo "snapshot_upgrade_paths=${SNAPSHOT_UPGRADE_PATHS}" >> "${GITHUB_OUTPUT}"
 echo "bc_upgrade_paths=${BC_UPGRADE_PATHS}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/generate-upgrade-paths/script.sh
+++ b/.github/workflows/generate-upgrade-paths/script.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 cd integrationservertest
 
-SNAPSHOT_UPGRADE_PATHS=$(go run ./scripts/genpath --target='qa' --snapshots=true)
-BC_UPGRADE_PATHS=$(go run ./scripts/genpath --target='qa' --snapshots=false)
+SNAPSHOT_UPGRADE_PATHS=$(go run ./scripts/genpath --target="${EC_TARGET:-pro}" --snapshots=true)
+BC_UPGRADE_PATHS=$(go run ./scripts/genpath --target="${EC_TARGET:-pro}" --snapshots=false)
 
 echo "snapshot_upgrade_paths=${SNAPSHOT_UPGRADE_PATHS}" >> "${GITHUB_OUTPUT}"
 echo "bc_upgrade_paths=${BC_UPGRADE_PATHS}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/setup-integration-server-test/action.yml
+++ b/.github/workflows/setup-integration-server-test/action.yml
@@ -2,12 +2,6 @@
 name: setup-integration-server-test
 description: Setup Integration Server Test
 
-inputs:
-  target:
-    description: Elastic Cloud target environment
-    required: false
-    default: qa
-
 runs:
   using: composite
   steps:
@@ -24,11 +18,11 @@ runs:
         project-id: 'elastic-observability-ci'
     - name: Configure Elastic Cloud target
       shell: bash
-      env:
-        EC_TARGET: ${{ inputs.target }}
-      run: echo "EC_TARGET=${EC_TARGET}" >> "${GITHUB_ENV}"
+      run: |
+        # EC_TARGET must correspond to the EC_API_KEY target below.
+        echo "EC_TARGET=qa" >> "${GITHUB_ENV}"
     - uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
       with:
         export_to_environment: true
         secrets: |-
-          EC_API_KEY:elastic-observability-ci/elastic-cloud-observability-team-${{ inputs.target }}-api-key
+          EC_API_KEY:elastic-observability-ci/elastic-cloud-observability-team-qa-api-key

--- a/.github/workflows/setup-integration-server-test/action.yml
+++ b/.github/workflows/setup-integration-server-test/action.yml
@@ -2,6 +2,12 @@
 name: setup-integration-server-test
 description: Setup Integration Server Test
 
+inputs:
+  target:
+    description: Elastic Cloud target environment
+    required: false
+    default: qa
+
 runs:
   using: composite
   steps:
@@ -16,8 +22,13 @@ runs:
       with:
         project-number: '911195782929'
         project-id: 'elastic-observability-ci'
+    - name: Configure Elastic Cloud target
+      shell: bash
+      env:
+        EC_TARGET: ${{ inputs.target }}
+      run: echo "EC_TARGET=${EC_TARGET}" >> "${GITHUB_ENV}"
     - uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
       with:
         export_to_environment: true
         secrets: |-
-          EC_API_KEY:elastic-observability-ci/elastic-cloud-observability-team-qa-api-key
+          EC_API_KEY:elastic-observability-ci/elastic-cloud-observability-team-${{ inputs.target }}-api-key

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,8 @@ testing/rally/corpora:
 # Integration Server Tests -- Upgrade tests for APM Server in ECH.
 ##############################################################################
 
+EC_TARGET ?= pro
+
 # Run integration server upgrade test on one scenario - Default / Reroute
 .PHONY: integration-server-test/upgrade
 integration-server-test/upgrade:
@@ -355,7 +357,7 @@ endif
 ifndef SCENARIO
 	$(error SCENARIO is not set)
 endif
-	@cd integrationservertest && go test -run=TestUpgrade/.*/$(SCENARIO) -v -timeout=90m -cleanup-on-failure=true -target="qa" -upgrade-path="$(UPGRADE_PATH)" ./
+	@cd integrationservertest && go test -run=TestUpgrade/.*/$(SCENARIO) -v -timeout=90m -cleanup-on-failure=true -target="$(EC_TARGET)" -upgrade-path="$(UPGRADE_PATH)" ./
 
 # Run integration server upgrade test on all scenarios
 .PHONY: integration-server-test/upgrade-all
@@ -363,7 +365,7 @@ integration-server-test/upgrade-all:
 ifndef UPGRADE_PATH
 	$(error UPGRADE_PATH is not set)
 endif
-	@cd integrationservertest && go test -run=TestUpgrade -v -timeout=90m -cleanup-on-failure=true -target="qa" -upgrade-path="$(UPGRADE_PATH)" ./
+	@cd integrationservertest && go test -run=TestUpgrade -v -timeout=90m -cleanup-on-failure=true -target="$(EC_TARGET)" -upgrade-path="$(UPGRADE_PATH)" ./
 
 ##############################################################################
 # Generating and linting API documentation

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ endif
 ifndef SCENARIO
 	$(error SCENARIO is not set)
 endif
-	@cd integrationservertest && go test -run=TestUpgrade/.*/$(SCENARIO) -v -timeout=90m -cleanup-on-failure=true -target="pro" -upgrade-path="$(UPGRADE_PATH)" ./
+	@cd integrationservertest && go test -run=TestUpgrade/.*/$(SCENARIO) -v -timeout=90m -cleanup-on-failure=true -target="qa" -upgrade-path="$(UPGRADE_PATH)" ./
 
 # Run integration server upgrade test on all scenarios
 .PHONY: integration-server-test/upgrade-all
@@ -363,7 +363,7 @@ integration-server-test/upgrade-all:
 ifndef UPGRADE_PATH
 	$(error UPGRADE_PATH is not set)
 endif
-	@cd integrationservertest && go test -run=TestUpgrade -v -timeout=90m -cleanup-on-failure=true -target="pro" -upgrade-path="$(UPGRADE_PATH)" ./
+	@cd integrationservertest && go test -run=TestUpgrade -v -timeout=90m -cleanup-on-failure=true -target="qa" -upgrade-path="$(UPGRADE_PATH)" ./
 
 ##############################################################################
 # Generating and linting API documentation


### PR DESCRIPTION
## Motivation/summary

The integration server test workflow loads the QA Elastic Cloud API key but still explicitly targets production. This causes its version lookup to authenticate the QA key against the production endpoint and fail with 401.

The regression was introduced by [#21222](https://github.com/elastic/apm-server/pull/21222), which changed the key from production to QA without updating these explicit production targets. The setup action now exports `EC_TARGET=qa` for upgrade-path generation and upgrade tests. A comment beside the setting requires it to match the API key target configured immediately below.

## Checklist

No changelog or documentation update is required for this CI-only change.

## How to test these changes

Manually dispatch the `integration-server-test` workflow from this branch and confirm the `Prepare tests` job completes without a 401 when generating upgrade paths.

## Related issues

Closes #21348