### PR TITLE
add warn log for sourcemap negative caching

### DIFF
--- a/internal/sourcemap/body_caching.go
+++ b/internal/sourcemap/body_caching.go
@@ -93,6 +93,10 @@ func (s *BodyCachingFetcher) Fetch(ctx context.Context, name, version, path stri
 	consumer, err := s.backend.Fetch(ctx, name, version, path)
 	if err != nil {
 		if errors.Is(err, errMalformedSourcemap) || errors.Is(err, errSourcemapSizeExceedsLimit) {
+			s.logger.Warnf(
+				"caching empty sourcemap due to permanent error: %s for sourcemap with name (%s), version (%s), path (%s)",
+				err.Error(), name, version, path,
+			)
 			s.add(key, nil)
 		}
 		return nil, err

--- a/internal/sourcemap/body_caching.go
+++ b/internal/sourcemap/body_caching.go
@@ -94,8 +94,8 @@ func (s *BodyCachingFetcher) Fetch(ctx context.Context, name, version, path stri
 	if err != nil {
 		if errors.Is(err, errMalformedSourcemap) || errors.Is(err, errSourcemapSizeExceedsLimit) {
 			s.logger.Warnf(
-				"caching empty sourcemap due to permanent error: %s for sourcemap with name (%s), version (%s), path (%s)",
-				err.Error(), name, version, path,
+				"caching empty sourcemap for name (%s), version (%s), path (%s) due to permanent error: %s",
+				name, version, path, err.Error(),
 			)
 			s.add(key, nil)
 		}

--- a/internal/sourcemap/body_caching_test.go
+++ b/internal/sourcemap/body_caching_test.go
@@ -141,7 +141,7 @@ func TestStore_Fetch(t *testing.T) {
 
 				// ensure the permanent-error warning is emitted
 				warnings := observed.FilterLevelExact(zapcore.WarnLevel).
-					FilterMessageSnippet("caching empty sourcemap due to permanent error").
+					FilterMessageSnippet("caching empty sourcemap for name").
 					All()
 				require.Len(t, warnings, 1)
 			})
@@ -181,7 +181,7 @@ func TestStore_Fetch(t *testing.T) {
 
 		// ensure the permanent-error warning is emitted
 		warnings := observed.FilterLevelExact(zapcore.WarnLevel).
-			FilterMessageSnippet("caching empty sourcemap due to permanent error").
+			FilterMessageSnippet("caching empty sourcemap for name").
 			All()
 		require.Len(t, warnings, 1)
 	})

--- a/internal/sourcemap/body_caching_test.go
+++ b/internal/sourcemap/body_caching_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/go-sourcemap/sourcemap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/elastic/apm-server/internal/elasticsearch"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
@@ -121,7 +123,7 @@ func TestStore_Fetch(t *testing.T) {
 			"unsupportedVersion": newMockElasticsearchClient(t, http.StatusOK, sourcemapESResponseBody(true, unsupportedVersionSourcemap)),
 		} {
 			t.Run(name, func(t *testing.T) {
-				store := testCachingFetcher(t, client)
+				store, observed := testCachingFetcherWithObserver(t, client)
 				//not cached
 				cached, found := store.cache.Get(key)
 				require.False(t, found)
@@ -136,6 +138,12 @@ func TestStore_Fetch(t *testing.T) {
 				cached, found = store.cache.Get(key)
 				assert.True(t, found)
 				assert.Nil(t, cached)
+
+				// ensure the permanent-error warning is emitted
+				warnings := observed.FilterLevelExact(zapcore.WarnLevel).
+					FilterMessageSnippet("caching empty sourcemap due to permanent error").
+					All()
+				require.Len(t, warnings, 1)
 			})
 		}
 	})
@@ -145,13 +153,14 @@ func TestStore_Fetch(t *testing.T) {
 		ch := make(chan []identifier)
 		close(ch)
 
+		logger, observed := logptest.NewTestingLoggerWithObserver(t, "")
 		esFetcher := &esFetcher{
 			client:                client,
 			index:                 "apm-*sourcemap*",
-			logger:                logptest.NewTestingLogger(t, ""),
+			logger:                logger,
 			maxSourceMapSizeBytes: 5,
 		}
-		store, err := NewBodyCachingFetcher(esFetcher, 100, ch, logptest.NewTestingLogger(t, ""))
+		store, err := NewBodyCachingFetcher(esFetcher, 100, ch, logger)
 		require.NoError(t, err)
 
 		// source map has not yet been fetched, so it should not be present in cache
@@ -169,6 +178,12 @@ func TestStore_Fetch(t *testing.T) {
 		cached, found = store.cache.Get(key)
 		assert.True(t, found)
 		assert.Nil(t, cached)
+
+		// ensure the permanent-error warning is emitted
+		warnings := observed.FilterLevelExact(zapcore.WarnLevel).
+			FilterMessageSnippet("caching empty sourcemap due to permanent error").
+			All()
+		require.Len(t, warnings, 1)
 	})
 
 	t.Run("noConnectionToES", func(t *testing.T) {
@@ -189,11 +204,17 @@ func TestStore_Fetch(t *testing.T) {
 }
 
 func testCachingFetcher(t *testing.T, client *elasticsearch.Client) *BodyCachingFetcher {
+	store, _ := testCachingFetcherWithObserver(t, client)
+	return store
+}
+
+func testCachingFetcherWithObserver(t *testing.T, client *elasticsearch.Client) (*BodyCachingFetcher, *observer.ObservedLogs) {
 	ch := make(chan []identifier)
 	close(ch)
 
-	esFetcher := NewElasticsearchFetcher(client, "apm-*sourcemap*", defaultMaxSourceMapSizeBytes, logptest.NewTestingLogger(t, ""))
-	cachingFetcher, err := NewBodyCachingFetcher(esFetcher, 100, ch, logptest.NewTestingLogger(t, ""))
+	logger, observed := logptest.NewTestingLoggerWithObserver(t, "")
+	esFetcher := NewElasticsearchFetcher(client, "apm-*sourcemap*", defaultMaxSourceMapSizeBytes, logger)
+	cachingFetcher, err := NewBodyCachingFetcher(esFetcher, 100, ch, logger)
 	require.NoError(t, err)
-	return cachingFetcher
+	return cachingFetcher, observed
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
The prior https://github.com/elastic/apm-server/pull/21520 PR added a sourcemap size limit, which introduced a second scenario where an empty sourcemap could be cached. These errors were only available as a debug logs in the source map processor and fetcher. This PR adds a warn log to users can troubleshoot instances when negative caching occurs. 

### Example logs
Initial logs when the sourcemap is first fetched from elasticsearch
```text
{"log.level":"warn","@timestamp":"2026-07-28T15:37:01.237-0700","log.logger":"beater.sourcemap","log.origin":{"function":"github.com/elastic/apm-server/internal/sourcemap.(*BodyCachingFetcher).Fetch","file.name":"sourcemap/body_caching.go","file.line":96},"message":"caching empty sourcemap due to permanent error: sourcemap size exceeds limit : decompressed source map exceeds limit of 1 bytes for sourcemap with name (target-app), version (1.0.0), path (/assets/app.min.js.map)","service.name":"apm-server","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2026-07-28T15:37:01.237-0700","log.logger":"beater.sourcemap","log.origin":{"function":"github.com/elastic/apm-server/internal/sourcemap.(*BodyCachingFetcher).add","file.name":"sourcemap/body_caching.go","file.line":110},"message":"Added id {target-app 1.0.0 /assets/app.min.js.map}. Cache now has 1 entries.","service.name":"apm-server","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2026-07-28T15:37:01.237-0700","log.logger":"beater.handler.stacktrace","log.origin":{"function":"github.com/elastic/apm-server/internal/sourcemap.BatchProcessor.processStacktraceFrame","file.name":"sourcemap/processor.go","file.line":124},"message":"failed to fetch sourcemap with name (target-app), version (1.0.0), path (/assets/app.min.js.map): sourcemap size exceeds limit : decompressed source map exceeds limit of 1 bytes","service.name":"apm-server","ecs.version":"1.6.0"}
```

Subsequent debug log when we read from the cache:
```text
{"log.level":"debug","@timestamp":"2026-07-28T15:42:07.208-0700","log.logger":"beater.handler.stacktrace","log.origin":{"function":"github.com/elastic/apm-server/internal/sourcemap.BatchProcessor.processStacktraceFrame","file.name":"sourcemap/processor.go","file.line":124},"message":"failed to fetch sourcemap with name (target-app), version (1.0.0), path (/assets/app.min.js.map): unable to find sourcemap for service.name=target-app service.version=1.0.0 bundle.path=/assets/app.min.js.map","service.name":"apm-server","ecs.version":"1.6.0"}
```


## How to test these changes

1. Added unit test
2. Full instructions for manual testing can be found in here: https://github.com/elastic/apm-server/pull/21520

