### PR TITLE
changelog: Add 9.5.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -28,11 +28,11 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ### Features and enhancements [apm-9.5.0-features-enhancements]
 
-* Add `max_sourcemap_size` configuration option for RUM source mapping with a default limit of 500MiB. ([#21520](https://github.com/elastic/apm-server/pull/21520))
+_No new features or enhancements_
 
 ### Fixes [apm-9.5.0-fixes]
 
-* Skip loading and applying source maps that exceed the configured size limit to prevent excessive memory usage. ([#21520](https://github.com/elastic/apm-server/pull/21520))
+* Skip loading and applying source maps that exceed the configured `max_sourcemap_size` limit (default 500MiB) to prevent excessive memory usage. ([#21520](https://github.com/elastic/apm-server/pull/21520))
 
 ## 9.4.4 [apm-9.4.4-release-notes]
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -24,17 +24,15 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [apm-next-fixes]
 % * 1 sentence describing the change. ([#PR number](https://github.com/elastic/apm-server/pull/PR number))
 
-% ## 9.5.0 [apm-9.5.0-release-notes]
+## 9.5.0 [apm-9.5.0-release-notes]
 
-% ### Features and enhancements [apm-9.5.0-features-enhancements]
-% * 1 sentence describing the change. ([#PR number](https://github.com/elastic/apm-server/pull/PR number))
+### Features and enhancements [apm-9.5.0-features-enhancements]
 
-% _No new features or enhancements_ 
+* Add `max_sourcemap_size` configuration option for RUM source mapping with a default limit of 500MiB. ([#21520](https://github.com/elastic/apm-server/pull/21520))
 
-% ### Fixes [apm-9.5.0-fixes]
-% * 1 sentence describing the change. ([#PR number](https://github.com/elastic/apm-server/pull/PR number))
+### Fixes [apm-9.5.0-fixes]
 
-% _No new fixes_ 
+* Skip loading and applying source maps that exceed the configured size limit to prevent excessive memory usage. ([#21520](https://github.com/elastic/apm-server/pull/21520))
 
 ## 9.4.4 [apm-9.4.4-release-notes]
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -26,10 +26,6 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ## 9.5.0 [apm-9.5.0-release-notes]
 
-### Features and enhancements [apm-9.5.0-features-enhancements]
-
-_No new features or enhancements_
-
 ### Fixes [apm-9.5.0-fixes]
 
 * Skip loading and applying source maps that exceed the configured `max_sourcemap_size` limit (default 500MiB) to prevent excessive memory usage. ([#21520](https://github.com/elastic/apm-server/pull/21520))


### PR DESCRIPTION
## Motivation/summary

9.5.0 release notes were still commented out in `docs/release-notes/index.md`. This adds the APM Server entries for the source map size limit change from [#21520](https://github.com/elastic/apm-server/pull/21520), based on the [9.5.0 test plan](https://github.com/elastic/apm-server/issues/21570).

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes



## Related issues



Made with [Cursor](https://cursor.com)