### PR TITLE
avoid panics in TestPublisherStopShutdownInactive by using in memory logs

### DIFF
--- a/internal/publish/pub_test.go
+++ b/internal/publish/pub_test.go
@@ -19,6 +19,7 @@ package publish_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
@@ -97,7 +99,7 @@ func newBlockingPipeline(t testing.TB) (*pipeline.Pipeline, *mockClient) {
 
 	pipe, err := pipeline.New(
 		beat.Info{
-			Logger: logptest.NewTestingLogger(t, "beat"),
+			Logger: newTestLogger(t, "beat"),
 		},
 		pipeline.Monitors{},
 		namespace,
@@ -137,4 +139,19 @@ func (c *mockClient) Publish(ctx context.Context, batch publisher.Batch) error {
 	}
 	batch.ACK()
 	return nil
+}
+
+// newTestLogger uses logp utilities to create an in memory
+// logger that is safer to use with go tests and go routines.
+// Outputs the logs on failure
+func newTestLogger(t testing.TB, selector string) *logp.Logger {
+	logger, logs := logptest.NewTestingLoggerWithObserver(t, selector)
+	t.Cleanup(func() {
+		if t.Failed() {
+			for _, entry := range logs.All() {
+				fmt.Printf("%s\t%s\t%s\n", entry.Time.Format(time.RFC3339), entry.Level, entry.Message)
+			}
+		}
+	})
+	return logger
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

TestPublisherStopShutdownInactive is flaky due to a potential for a routine to write to the logs after the test function has returned. The shutdown sequence used in the test cleanup:
https://github.com/elastic/beats/blob/50ef57e75fbd5b2923a308da39a27d1ce24185c3/libbeat/publisher/pipeline/consumer.go#L237 might happen before the queueReader had a chance to log its stop message. Therefore, the cleanup might exit too early. This commit bypasses this problem by using logp.NewTestingLoggerWithObserver which still returns a logging output using *testing.T but an in memory slice of the logs to bypass the cleanup panics.

Reference for ogp.NewTestingLoggerWithObserver: https://github.com/elastic/elastic-agent-libs/blob/main/logp/logptest/logptest.go#L46

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes
I used the following steps to reproduce the problem and also check if the fix works

1. Clone beats and add the replace directive + go mod tidy
2. Add the delay to queueReader after the "stop" log: https://github.com/elastic/beats/blob/50ef57e75fbd5b2923a308da39a27d1ce24185c3/libbeat/publisher/pipeline/queue_reader.go#L76
3. In newTestLogger, swap the body to return logptest.NewTestingLogger(t, selector)
4. Run go test -count=2 ./internal/publish/... and observe the panic
5. Revert step 3 and re-run to confirm it's fixed

## Related issues
https://github.com/elastic/apm-server/issues/21375
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
