### PR TITLE
fix(bk): use literal dot in version bump grep to correctly detect minor releases

### DIFF
--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -23,13 +23,13 @@ steps:
   - label: "Validate WORKFLOW and NEW_VERSION consistency"
     command: |
       if [ "$${WORKFLOW}" = "minor" ]; then
-        if ! echo "$${NEW_VERSION}" | grep -q '.0$$'; then
+        if ! echo "$${NEW_VERSION}" | grep -q '\.0$$'; then
           echo "❌ Error: WORKFLOW is 'minor' but NEW_VERSION ($${NEW_VERSION}) does not end with 0"
           exit 1
         fi
         echo "✅ Valid: WORKFLOW is 'minor' and NEW_VERSION ($${NEW_VERSION}) ends with 0"
       elif [ "$${WORKFLOW}" = "patch" ]; then
-        if echo "$${NEW_VERSION}" | grep -q '.0$$'; then
+        if echo "$${NEW_VERSION}" | grep -q '\.0$$'; then
           echo "❌ Error: WORKFLOW is 'patch' but NEW_VERSION ($${NEW_VERSION}) ends with 0"
           exit 1
         fi


### PR DESCRIPTION
## Summary

Patch versions ending in \`0\` (e.g. \`8.19.20\`) were incorrectly rejected by the version bump pipeline validation because \`grep -q '.0$'\` treats \`.\` as "any character", matching \`20\`, \`10\`, \`30\`, etc.

Changed to \`grep -q '\.0$'\` (literal dot) so only true minor release versions (\`X.Y.0\`) match the pattern.

## Root cause

The validation has had three attempts:
- \`fe5b2d65\` (Mar 23): original code used \`'0$'\` — matches any version ending in digit 0
- \`c50453e3\` (Mar 26): changed to \`'.0$'\` — still wrong, \`.'\` in grep = any char
- \`1bbfd5df\` (Jul 21): same \`'.0$'\` pattern — still incorrect

Build [apm-server-version-bump #26](https://buildkite.com/elastic/apm-server-version-bump/builds/26) failed for this reason when bumping to \`8.19.20\`.

## Test plan

- [ ] Trigger a patch bump with a version like \`8.19.20\` — should pass validation
- [ ] Trigger a minor bump with a version like \`8.20.0\` — should pass validation
- [ ] Trigger a patch bump with \`8.20.0\` — should correctly fail validation