### PR TITLE
[8.19] Fix DRA annotate link to point at the published summary, not the temp path

### DIFF
--- a/.buildkite/scripts/dra-annotate.sh
+++ b/.buildkite/scripts/dra-annotate.sh
@@ -4,11 +4,9 @@
 ##  extracts build_id and version, and annotates the build with a link to
 ##  the workflow's published summary.
 ##
-##  dractl prep never writes a summary-*.html at its temp upload path (only
-##  the manifest) — the rendered summary only exists once
-##  unified-release-dra-processing publishes it to the final location, so
-##  link there instead of the temp path.
-##
+##  The rendered summary only exists once unified-release-dra-processing
+##  publishes it to the final location.
+##  
 ##  Invoked from the generated DRA sub-pipeline. Kept as a standalone script
 ##  because Buildkite interpolates inline command:'s ${VAR} references at
 ##  job pickup, which would eat local variables set inside the command block.

--- a/.buildkite/scripts/dra-annotate.sh
+++ b/.buildkite/scripts/dra-annotate.sh
@@ -2,9 +2,12 @@
 ##
 ##  Downloads the DRA manifest from the dra-prep-${WORKFLOW} step,
 ##  extracts build_id and version, and annotates the build with a link to
-##  the workflow's summary at dra-prep plugin's temp upload path.
+##  the workflow's published summary.
 ##
-##  Link the temp path so the annotation is live the moment dra-prep plugin finishes.
+##  dractl prep never writes a summary-*.html at its temp upload path (only
+##  the manifest) — the rendered summary only exists once
+##  unified-release-dra-processing publishes it to the final location, so
+##  link there instead of the temp path.
 ##
 ##  Invoked from the generated DRA sub-pipeline. Kept as a standalone script
 ##  because Buildkite interpolates inline command:'s ${VAR} references at
@@ -17,8 +20,9 @@ WORKFLOW="${1:?workflow required}"
 
 buildkite-agent artifact download "artifacts/dra/apm-server/*/manifest-*.json" . --step "dra-prep-${WORKFLOW}"
 manifest=$(find artifacts/dra/apm-server -name "manifest-*.json" | head -1)
+prefix=$(jq -r '.prefix' "${manifest}")
 build_id=$(jq -r '.build_id' "${manifest}")
 version=$(jq -r '.version' "${manifest}")
-url="https://artifacts-${WORKFLOW}.elastic.co/dra-builds/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_BUILD_NUMBER}/${build_id}/summary-${version}.html"
+url="https://artifacts-${WORKFLOW}.elastic.co/${prefix}/${build_id}/summary-${version}.html"
 
 printf "**%s summary link:** [%s](%s)\n" "${WORKFLOW}" "${url}" "${url}" | buildkite-agent annotate --style=success --append


### PR DESCRIPTION
## What this changes

Same fix as #21780 (main), applied to `8.19` since the original DRA-prep migration backport (already merged) carried the same bug.

`dra-annotate.sh` linked the DRA build summary at `dra-prep`'s temp GCS upload path (`dra-builds/<pipeline>/<build_number>/<build_id>/summary-<version>.html`). That path never has a `summary-*.html` — `dractl prep` only writes the manifest there. The rendered summary only exists once `unified-release-dra-processing` publishes it to the final location (`<prefix>/<build_id>/summary-<version>.html`), so the annotation link 404s permanently.

Fix: read the `prefix` field already present in the manifest and link the final published path instead.

## Testing

Verified against a real production annotation from cloudbeat (same reference implementation, same bug): the temp-path URL 404s, the final-path URL (same shape this PR produces) returns 200 and renders the real summary page.