### PR TITLE
test: Workaround beats pipeline logging panic

### DIFF
--- a/internal/publish/pub_test.go
+++ b/internal/publish/pub_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	"github.com/elastic/apm-server/internal/publish"
@@ -95,9 +95,12 @@ func newBlockingPipeline(t testing.TB) (*pipeline.Pipeline, *mockClient) {
 	err = conf.Unpack(&namespace)
 	require.NoError(t, err)
 
+	// TODO: remove noplogger workaround once https://github.com/elastic/beats/issues/52947 is fixed upstream.
+	// The pipeline's internal queueReader goroutine may log after a test completes, causing a
+	// panic when using zaptest's testing logger. A nop logger avoids the race.
 	pipe, err := pipeline.New(
 		beat.Info{
-			Logger: logptest.NewTestingLogger(t, "beat"),
+			Logger: logp.NewNopLogger(),
 		},
 		pipeline.Monitors{},
 		namespace,


### PR DESCRIPTION
## Motivation/summary

`TestPublisherStopShutdownInactive` panics intermittently because the beats pipeline internal `queueReader` goroutine is intentionally excluded from the pipeline shutdown `WaitGroup` (see elastic/beats#52947). It can continue running and emitting log calls after `pipe.Disconnect()` returns. When the test uses `logptest.NewTestingLogger(t, ...)` (backed by `zaptest.TestingWriter`), any log call that arrives after the test has completed triggers a fatal panic.

Work around this by switching `newBlockingPipeline` in the test to `logp.NewNopLogger()`, so stray post-shutdown log calls are silently dropped.

## Checklist

- Not a user-facing change; CHANGELOG not required.
- Documentation not affected.

## How to test these changes

```
go test -count=10 -run TestPublisherStop ./internal/publish/...
```

Both `TestPublisherStop` and `TestPublisherStopShutdownInactive` should pass reliably.

## Related issues

Closes #21375
Workaround for elastic/beats#52947 (TODO to remove once that is fixed upstream)
