### PR TITLE
test: do not run make test in verbose mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ include release.mk
 
 # By default we run tests with verbose output. This may be overridden, e.g.
 # scripts may set GOTESTFLAGS=-json to format test output for processing.
-GOTESTFLAGS?=-v
+GOTESTFLAGS?=
 
 # Prevent unintended modifications of go.[mod|sum]
 GOMODFLAG?=-mod=readonly

--- a/internal/beater/otlp/http_test.go
+++ b/internal/beater/otlp/http_test.go
@@ -154,7 +154,7 @@ func TestConsumeLogsHTTP(t *testing.T) {
 	require.Len(t, batches, 1)
 
 	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
-		"http.server.request.count":        1,
+		"http.server.request.count":        2,
 		"http.server.response.count":       1,
 		"http.server.response.valid.count": 1,
 	})

--- a/internal/beater/otlp/http_test.go
+++ b/internal/beater/otlp/http_test.go
@@ -154,7 +154,7 @@ func TestConsumeLogsHTTP(t *testing.T) {
 	require.Len(t, batches, 1)
 
 	monitoringtest.ExpectContainOtelMetrics(t, reader, map[string]any{
-		"http.server.request.count":        2,
+		"http.server.request.count":        1,
 		"http.server.response.count":       1,
 		"http.server.response.valid.count": 1,
 	})


### PR DESCRIPTION
## Motivation/summary

since we use the testlogger and properly use the testing.T logger we don't need to print to stdout and can rely on native go test infra to print logs on test failure

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
