### PR TITLE
refactor: drop unused beats ldflags fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,7 @@ APM_SERVER_FIPS_BINARIES:= \
 # Strip binary and inject the Git commit hash and timestamp.
 LDFLAGS := \
 	-s \
-	-X github.com/elastic/apm-server/internal/version.qualifier=$(ELASTIC_QUALIFIER) \
-	-X github.com/elastic/beats/v7/libbeat/version.commit=$(GITCOMMIT) \
-	-X github.com/elastic/beats/v7/libbeat/version.buildTime=$(GITCOMMITTIMESTAMP)
+	-X github.com/elastic/apm-server/internal/version.qualifier=$(ELASTIC_QUALIFIER)
 
 # Rule to build apm-server fips binaries
 .PHONY: $(APM_SERVER_FIPS_BINARIES)

--- a/go.mk
+++ b/go.mk
@@ -1,7 +1,5 @@
 GITDIR ?= $(shell git rev-parse --git-dir)
 GITCOMMIT ?= $(shell git rev-parse HEAD)
-GITCOMMITTIMESTAMP ?= $(shell git log -1 --pretty=%cI)
-GITCOMMITTIMESTAMPUNIX ?= $(shell git log -1 --pretty=%ct)
 GITREFFILE ?= $(GITDIR)/$(shell git rev-parse --symbolic-full-name HEAD)
 GITROOT ?= $(shell git rev-parse --show-toplevel)
 


### PR DESCRIPTION
## Motivation/summary

beats reads commit and timestampt from buildinfo so the ldflags are unused

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
